### PR TITLE
Enable non-sequential block finalization.

### DIFF
--- a/substrate/client/api/src/backend.rs
+++ b/substrate/client/api/src/backend.rs
@@ -551,6 +551,7 @@ pub trait Backend<Block: BlockT>: AuxStore + Send + Sync {
 		&self,
 		hash: Block::Hash,
 		justification: Option<Justification>,
+		ensure_sequential_finalization: bool,
 	) -> sp_blockchain::Result<()>;
 
 	/// Append justification to the block with the given `hash`.

--- a/substrate/client/api/src/in_mem.rs
+++ b/substrate/client/api/src/in_mem.rs
@@ -712,6 +712,7 @@ impl<Block: BlockT> backend::Backend<Block> for Backend<Block> {
 		&self,
 		hash: Block::Hash,
 		justification: Option<Justification>,
+		_ensure_sequesntial_finalization: bool,
 	) -> sp_blockchain::Result<()> {
 		self.blockchain.finalize_header(hash, justification)
 	}

--- a/substrate/client/service/src/client/client.rs
+++ b/substrate/client/service/src/client/client.rs
@@ -128,6 +128,10 @@ where
 	fn clear_block_gap(&self) -> sp_blockchain::Result<()> {
 		self.backend.blockchain().clear_block_gap()
 	}
+
+	fn finalize_block(&self, hash: Block::Hash) -> sp_blockchain::Result<()> {
+		self.backend.finalize_block(hash, None, false)
+	}
 }
 
 /// Used in importing a block, where additional changes are made after the runtime

--- a/substrate/client/service/src/lib.rs
+++ b/substrate/client/service/src/lib.rs
@@ -106,6 +106,9 @@ pub struct RpcHandlers(Arc<RpcModule<()>>);
 pub trait ClientExt<Block: BlockT, B: backend::Backend<Block>> {
 	/// Clear block gap after initial block insertion.
 	fn clear_block_gap(&self) -> sp_blockchain::Result<()>;
+
+	/// Finalize block disabling sequential order check.
+	fn finalize_block(&self, hash: Block::Hash) -> sp_blockchain::Result<()>;
 }
 
 impl RpcHandlers {


### PR DESCRIPTION
This PR prepares the polkadot-sdk for enabling non-sequential block finalization in subspace blockchain.

During the snap-sync the code invokes `apply_finality` method which implies sequential block order and fails otherwise. Additionally, the recently modified `displaced_leaves_after_finalizing` tries to find the parent header of the last finalized block and fails after snap-sync(that block is the first available block inserted by the newly added `finalize_block` API and contains no parent header in blockchain db).

The proposed changes export `finalize_block` API that enables block finalization by disabling sequential block order check, also, the changes soften the error handling for `displaced_leaves_after_finalizing` and allows it to continue after accessing non-existent block header.