### PR TITLE
expose extension weights

### DIFF
--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -171,6 +171,7 @@ pub use extensions::{
 	check_non_zero_sender::CheckNonZeroSender, check_nonce::CheckNonce,
 	check_spec_version::CheckSpecVersion, check_tx_version::CheckTxVersion,
 	check_weight::CheckWeight, WeightInfo as ExtensionsWeightInfo,
+	weights::SubstrateWeight as ExtensionsWeight
 };
 // Backward compatible re-export.
 pub use extensions::check_mortality::CheckMortality as CheckEra;


### PR DESCRIPTION
Expose the Weights that use Config::DbWeights

Upstream PR: https://github.com/paritytech/polkadot-sdk/pull/7637/files