### PR TITLE
Make rocksdb optional 

### DIFF
--- a/cumulus/client/cli/Cargo.toml
+++ b/cumulus/client/cli/Cargo.toml
@@ -14,13 +14,13 @@ clap = { features = ["derive"], workspace = true }
 codec = { workspace = true, default-features = true }
 url = { workspace = true }
 sc-cli.workspace = true
-sc-cli.default-features = true
+sc-cli.default-features = false
 sc-client-api.workspace = true
 sc-client-api.default-features = true
 sc-chain-spec.workspace = true
 sc-chain-spec.default-features = true
 sc-service.workspace = true
-sc-service.default-features = true
+sc-service.default-features = false
 sp-core.workspace = true
 sp-core.default-features = true
 sp-runtime.workspace = true

--- a/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/cumulus/client/relay-chain-inprocess-interface/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 sc-cli.workspace = true
-sc-cli.default-features = true
+sc-cli.default-features = false
 sc-client-api.workspace = true
 sc-client-api.default-features = true
 sc-telemetry.workspace = true

--- a/cumulus/polkadot-omni-node/lib/Cargo.toml
+++ b/cumulus/polkadot-omni-node/lib/Cargo.toml
@@ -40,7 +40,7 @@ sc-consensus.workspace = true
 sc-consensus.default-features = true
 frame-support = { optional = true, workspace = true, default-features = true }
 sc-cli.workspace = true
-sc-cli.default-features = true
+sc-cli.default-features = false
 sc-client-api.workspace = true
 sc-client-api.default-features = true
 sc-client-db.workspace = true
@@ -48,7 +48,7 @@ sc-client-db.default-features = true
 sc-executor.workspace = true
 sc-executor.default-features = true
 sc-service.workspace = true
-sc-service.default-features = true
+sc-service.default-features = false
 sc-telemetry.workspace = true
 sc-telemetry.default-features = true
 sc-transaction-pool.workspace = true

--- a/polkadot/cli/Cargo.toml
+++ b/polkadot/cli/Cargo.toml
@@ -35,8 +35,8 @@ sp-keyring.default-features = true
 sp-maybe-compressed-blob.workspace = true
 sp-maybe-compressed-blob.default-features = true
 frame-benchmarking-cli = { optional = true, workspace = true, default-features = true }
-sc-cli = { optional = true, workspace = true, default-features = true }
-sc-service = { optional = true, workspace = true, default-features = true }
+sc-cli = { optional = true, workspace = true, default-features = false }
+sc-service = { optional = true, workspace = true, default-features = false }
 polkadot-node-metrics.workspace = true
 polkadot-node-metrics.default-features = true
 polkadot-node-primitives.workspace = true

--- a/polkadot/node/metrics/Cargo.toml
+++ b/polkadot/node/metrics/Cargo.toml
@@ -17,9 +17,9 @@ gum.default-features = true
 
 metered = { features = ["futures_channel"], workspace = true }
 sc-service.workspace = true
-sc-service.default-features = true
+sc-service.default-features = false
 sc-cli.workspace = true
-sc-cli.default-features = true
+sc-cli.default-features = false
 prometheus-endpoint.workspace = true
 prometheus-endpoint.default-features = true
 sc-tracing.workspace = true

--- a/substrate/client/cli/Cargo.toml
+++ b/substrate/client/cli/Cargo.toml
@@ -37,14 +37,14 @@ bip39 = { package = "parity-bip39", version = "2.0.1", features = ["rand"] }
 tokio = { features = ["parking_lot", "rt-multi-thread", "signal"], workspace = true, default-features = true }
 sc-client-api.workspace = true
 sc-client-api.default-features = true
-sc-client-db.workspace = true
+sc-client-db = { workspace = true, default-features = false }
 sc-keystore.workspace = true
 sc-keystore.default-features = true
 sc-mixnet.workspace = true
 sc-mixnet.default-features = true
 sc-network.workspace = true
 sc-network.default-features = true
-sc-service.workspace = true
+sc-service = {workspace = true, default-features = false}
 sc-telemetry.workspace = true
 sc-telemetry.default-features = true
 sc-tracing.workspace = true

--- a/substrate/test-utils/cli/Cargo.toml
+++ b/substrate/test-utils/cli/Cargo.toml
@@ -28,9 +28,9 @@ node-primitives.workspace = true
 node-primitives.default-features = true
 node-cli.workspace = true
 sc-cli.workspace = true
-sc-cli.default-features = true
+sc-cli.default-features = false
 sc-service.workspace = true
-sc-service.default-features = true
+sc-service.default-features = false
 futures = { workspace = true }
 
 [features]

--- a/substrate/test-utils/client/Cargo.toml
+++ b/substrate/test-utils/client/Cargo.toml
@@ -24,14 +24,14 @@ serde = { workspace = true, default-features = true }
 serde_json = { workspace = true, default-features = true }
 sc-client-api.workspace = true
 sc-client-api.default-features = true
-sc-client-db = { features = ["test-helpers"], workspace = true }
+sc-client-db = { features = ["test-helpers"], workspace = true, default-features = false}
 sc-consensus.workspace = true
 sc-consensus.default-features = true
 sc-executor.workspace = true
 sc-executor.default-features = true
 sc-offchain.workspace = true
 sc-offchain.default-features = true
-sc-service = { features = ["test-helpers"], workspace = true }
+sc-service = { features = ["test-helpers"], workspace = true, default-features = false }
 sp-blockchain.workspace = true
 sp-blockchain.default-features = true
 sp-consensus.workspace = true

--- a/substrate/utils/frame/benchmarking-cli/Cargo.toml
+++ b/substrate/utils/frame/benchmarking-cli/Cargo.toml
@@ -41,14 +41,14 @@ frame-system.default-features = true
 sc-block-builder.workspace = true
 sc-block-builder.default-features = true
 sc-chain-spec.workspace = true
-sc-cli.workspace = true
+sc-cli = { workspace = true, default-features = false }
 sc-client-api.workspace = true
 sc-client-api.default-features = true
-sc-client-db.workspace = true
+sc-client-db = { workspace = true, default-features = false }
 sc-executor.workspace = true
 sc-executor.default-features = true
 sc-executor-common.workspace = true
-sc-service.workspace = true
+sc-service = { workspace = true, default-features = false }
 sc-sysinfo.workspace = true
 sc-sysinfo.default-features = true
 sp-api.workspace = true
@@ -108,7 +108,7 @@ substrate-test-runtime = { default-features = true, path = "../../../test-utils/
 westend-runtime = { default-features = true, path = "../../../../polkadot/runtime/westend" }
 
 [features]
-default = ["rocksdb"]
+default = []
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",

--- a/substrate/utils/frame/benchmarking-cli/src/overhead/command.rs
+++ b/substrate/utils/frame/benchmarking-cli/src/overhead/command.rs
@@ -478,7 +478,7 @@ impl OverheadCmd {
 		let database_source = self.database_config(
 			&base_path.path().to_path_buf(),
 			self.database_cache_size()?.unwrap_or(1024),
-			self.database()?.unwrap_or(Database::RocksDb),
+			self.database()?.unwrap_or(Database::Auto),
 		)?;
 
 		let backend = new_db_backend(DatabaseSettings {


### PR DESCRIPTION
sc-cli was bringing rocksdb as default and so rocksdb is pulled in 

Upstream PR: https://github.com/paritytech/polkadot-sdk/pull/7649