### PR TITLE
Introduce event segment to store multiple events under one key

### DIFF
--- a/substrate/frame/system/src/lib.rs
+++ b/substrate/frame/system/src/lib.rs
@@ -2059,6 +2059,10 @@ impl<T: Config> Pallet<T> {
 	///
 	/// This needs to be used in prior calling [`initialize`](Self::initialize) for each new block
 	/// to clear events from previous block.
+	///
+	/// NOTE: when the event segment is used (i.e. `EventSegmentSize` > 0) the event is not really
+	/// cleared from the storage, it only resets the event counter and the event will be overwritten
+	/// by the new event from the next block.
 	pub fn reset_events() {
 		if T::EventSegmentSize::get().is_zero() {
 			<Events<T>>::kill();

--- a/substrate/frame/system/src/migrations/mod.rs
+++ b/substrate/frame/system/src/migrations/mod.rs
@@ -18,11 +18,12 @@
 //! Migrate the reference counting state.
 
 use super::LOG_TARGET;
-use crate::{Config, Pallet};
+use crate::{Config, Events, Pallet, UnclearedEventCount};
 use codec::{Decode, Encode, FullCodec};
 use frame_support::{
 	pallet_prelude::ValueQuery, traits::PalletInfoAccess, weights::Weight, Blake2_128Concat,
 };
+use sp_core::Get;
 use sp_runtime::RuntimeDebug;
 
 /// Type used to encode the number of references an account has.
@@ -118,4 +119,11 @@ pub fn migrate_from_dual_to_triple_ref_count<V: V2ToV3, T: Config>() -> Weight {
 	);
 	<UpgradedToTripleRefCount<T>>::put(true);
 	Weight::MAX
+}
+
+/// Migrate from `Events` to `EventSegments` when `T::EventSegmentSize > 0`
+pub fn migrate_from_events_to_event_segments<T: Config>() -> Weight {
+	Events::<T>::kill();
+	UnclearedEventCount::<T>::set(0);
+	T::DbWeight::get().writes(2u64)
 }

--- a/substrate/frame/system/src/mock.rs
+++ b/substrate/frame/system/src/mock.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::{self as frame_system, *};
+use core::sync::atomic::{AtomicU32, Ordering};
 use frame_support::{derive_impl, parameter_types};
 use sp_runtime::{type_with_default::TypeWithDefault, BuildStorage, Perbill};
 
@@ -96,10 +97,20 @@ impl Config for Test {
 	type OnKilledAccount = RecordKilled;
 	type MultiBlockMigrator = MockedMigrator;
 	type Nonce = TypeWithDefault<u64, DefaultNonceProvider>;
+	type EventSegmentSize = EventSegmentSize;
 }
 
 parameter_types! {
 	pub static Ongoing: bool = false;
+}
+
+pub static EVENT_SEGMENT_SIZE_VALUE: AtomicU32 = AtomicU32::new(0u32);
+
+pub struct EventSegmentSize;
+impl Get<u32> for EventSegmentSize {
+	fn get() -> u32 {
+		EVENT_SEGMENT_SIZE_VALUE.load(Ordering::SeqCst)
+	}
 }
 
 pub struct MockedMigrator;

--- a/substrate/frame/system/src/tests.rs
+++ b/substrate/frame/system/src/tests.rs
@@ -16,6 +16,7 @@
 // limitations under the License.
 
 use crate::*;
+use core::sync::atomic::Ordering;
 use frame_support::{
 	assert_noop, assert_ok,
 	dispatch::{Pays, PostDispatchInfo, WithPostDispatchInfo},
@@ -890,5 +891,140 @@ fn test_default_account_nonce() {
 
 		Account::<Test>::remove(&1);
 		assert_eq!(System::account_nonce(&1), 5u64.into());
+	});
+}
+
+#[test]
+fn test_event_segment() {
+	new_test_ext().execute_with(|| {
+		// Set the `EventSegmentSize` to 0, the event will store in `Events` instead of `EventSegments`
+		System::reset_events();
+		EVENT_SEGMENT_SIZE_VALUE.store(0u32, Ordering::SeqCst);
+		System::initialize(&1, &[0u8; 32].into(), &Default::default());
+		System::note_finished_extrinsics();
+		System::deposit_event(SysEvent::CodeUpdated);
+		System::finalize();
+		assert_eq!(
+			System::events(),
+			vec![EventRecord {
+				phase: Phase::Finalization,
+				event: SysEvent::CodeUpdated.into(),
+				topics: vec![],
+			}]
+		);
+		assert_eq!(Events::<Test>::get().len(), 1);
+		assert_eq!(EventSegments::<Test>::iter().count(), 0);
+
+		// Set the `EventSegmentSize` > 0, the event will store in `EventSegments` instead of `Events`
+		System::reset_events();
+		assert!(System::events().is_empty());
+		EVENT_SEGMENT_SIZE_VALUE.store(1u32, Ordering::SeqCst);
+		System::initialize(&2, &[0u8; 32].into(), &Default::default());
+		for i in 0..10 {
+			System::deposit_event(SysEvent::NewAccount { account: i as u64 + 1 });
+		}
+		System::note_finished_initialize();
+		System::note_finished_extrinsics();
+		System::finalize();
+		for (i, event) in System::events().into_iter().enumerate() {
+			assert_eq!(
+				event,
+				EventRecord {
+					phase: Phase::Initialization,
+					event: SysEvent::NewAccount { account: i as u64 + 1 }.into(),
+					topics: vec![]
+				}
+			);
+		}
+		assert_eq!(Events::<Test>::get().len(), 0);
+		assert_eq!(EventSegments::<Test>::iter().count(), 10);
+
+		// Set the `EventSegmentSize` to 2, each event segment will at most contains 2 events
+		System::reset_events();
+		assert!(System::events().is_empty());
+		EVENT_SEGMENT_SIZE_VALUE.store(2u32, Ordering::SeqCst);
+		System::initialize(&3, &[0u8; 32].into(), &Default::default());
+		System::note_finished_initialize();
+		System::note_finished_extrinsics();
+		for i in 10..15 {
+			System::deposit_event(SysEvent::NewAccount { account: i as u64 + 1 });
+		}
+		System::finalize();
+		assert_eq!(Events::<Test>::get().len(), 0);
+
+		// 5 events from the current block stored in the first 3 segments
+		assert_eq!(
+			EventSegments::<Test>::get(0).unwrap(),
+			vec![
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount { account: 11 }.into(),
+					topics: vec![]
+				}
+				.into(),
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount { account: 12 }.into(),
+					topics: vec![]
+				}
+				.into()
+			]
+		);
+		assert_eq!(
+			EventSegments::<Test>::get(1).unwrap(),
+			vec![
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount { account: 13 }.into(),
+					topics: vec![]
+				}
+				.into(),
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount { account: 14 }.into(),
+					topics: vec![]
+				}
+				.into()
+			]
+		);
+		assert_eq!(
+			EventSegments::<Test>::get(2).unwrap(),
+			vec![EventRecord {
+				phase: Phase::Finalization,
+				event: SysEvent::NewAccount { account: 15 }.into(),
+				topics: vec![]
+			}
+			.into()]
+		);
+
+		// The events from the previous block is not cleared in `EventSegments`
+		assert_eq!(EventSegments::<Test>::iter().count(), 10);
+		assert_eq!(UnclearedEventCount::<Test>::get(), 10);
+		for i in 3..10 {
+			assert_eq!(
+				EventSegments::<Test>::get(i).unwrap(),
+				vec![EventRecord {
+					phase: Phase::Initialization,
+					event: SysEvent::NewAccount { account: i as u64 + 1 }.into(),
+					topics: vec![]
+				}
+				.into()]
+			);
+		}
+
+		// But also inaccessible by `System::events()`
+		for (i, event) in System::events().into_iter().enumerate() {
+			assert_eq!(
+				event,
+				EventRecord {
+					phase: Phase::Finalization,
+					event: SysEvent::NewAccount { account: i as u64 + 11 }.into(),
+					topics: vec![]
+				}
+			);
+		}
+
+		System::reset_events();
+		assert!(System::events().is_empty());
 	});
 }


### PR DESCRIPTION
With `StorageValue` the `Events` is a single array in the state that keep growing as more extrinsic is executed and more events append to this array, which makes execution and storage root calculation slower and slower as allocation/copying/hashing this array takes more and more time.

This PR introduces event segment to store multiple events under one key in a `StorageMap`. The size of the segment is defined by a new config item `EventSegmentSize`, while a larger segment leads toward the same issue as the `StorageValue` `Events`, a smaller segment brings more items to the Trie and may impact performance. From the [benchmark result](https://github.com/paritytech/polkadot-sdk/issues/278#issuecomment-2665929051) 100 maybe a good parameter for us.

Also, when `EventSegmentSize` is set to zero the event segment is disabled to avoid unexpected breaking change.