### PR TITLE
Fix incorrect peer port autodetection and substream limit exceeded errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,34 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-primitives"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6259a506ab13e1d658796c31e6e39d2e2ee89243bcc505ddc613b35732e0a430"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 1.0.0",
- "foldhash",
- "hashbrown 0.15.2",
- "hex-literal",
- "indexmap 2.7.1",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.8.5",
- "ruint",
- "rustc-hash 2.0.0",
- "serde",
- "sha3 0.10.8",
- "tiny-keccak",
-]
-
-[[package]]
 name = "alloy-rlp"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,63 +171,6 @@ dependencies = [
  "syn 2.0.87",
  "syn-solidity",
  "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9d64f851d95619233f74b310f12bcf16e0cbc27ee3762b6115c14a84809280a"
-dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
- "proc-macro-error2",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "alloy-sol-macro-expander"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf7ed1574b699f48bf17caab4e6e54c6d12bc3c006ab33d58b1e227c1c3559f"
-dependencies = [
- "alloy-sol-macro-input",
- "const-hex",
- "heck 0.5.0",
- "indexmap 2.7.1",
- "proc-macro-error2",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
- "syn-solidity 0.8.15",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-sol-macro-input"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c02997ccef5f34f9c099277d4145f183b422938ed5322dc57a089fe9b9ad9ee"
-dependencies = [
- "const-hex",
- "dunce",
- "heck 0.5.0",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
- "syn-solidity 0.8.15",
-]
-
-[[package]]
-name = "alloy-sol-type-parser"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce13ff37285b0870d0a0746992a4ae48efaf34b766ae4c2640fa15e5305f8e73"
-dependencies = [
- "serde",
- "winnow 0.6.18",
 ]
 
 [[package]]
@@ -794,9 +709,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
  "synstructure 0.13.1",
 ]
 
@@ -1541,27 +1456,6 @@ dependencies = [
  "miniz_oxide",
  "object 0.32.2",
  "rustc-demangle",
-]
-
-[[package]]
-name = "bandersnatch_vrfs"
-version = "0.0.4"
-source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "dleq_vrf",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "ring 0.1.0",
- "sha2 0.10.8",
- "sp-ark-bls12-381",
- "sp-ark-ed-on-bls12-381-bandersnatch",
- "zeroize",
 ]
 
 [[package]]
@@ -2700,9 +2594,6 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bzip2-sys"
@@ -3371,22 +3262,6 @@ dependencies = [
  "strum 0.25.0",
  "strum_macros 0.25.3",
  "unicode-width",
-]
-
-[[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/w3f/ring-proof?rev=665f5f5#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "fflonk",
- "getrandom_or_panic",
- "merlin",
- "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -4255,9 +4130,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-inherents",
+ "sp-runtime 40.1.0",
+ "sp-state-machine 0.44.0",
  "thiserror 1.0.65",
 ]
 
@@ -4357,7 +4232,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
+ "portpicker",
  "rand 0.8.5",
  "rstest",
  "sc-cli",
@@ -4469,8 +4345,9 @@ dependencies = [
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-runtime-parachains 7.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
+ "polkadot-runtime-parachains",
  "rand 0.8.5",
  "sc-client-api",
  "scale-info",
@@ -4734,8 +4611,8 @@ dependencies = [
  "sc-client-api",
  "sp-api 35.0.0",
  "sp-blockchain",
- "sp-state-machine 0.35.0",
- "sp-version 29.0.0",
+ "sp-state-machine 0.44.0",
+ "sp-version 38.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -5838,25 +5715,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
- "ethereum-types 0.14.1",
- "hex",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha3 0.10.8",
- "thiserror 1.0.65",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "ethabi-decode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d398648d65820a727d6a81e58b962f874473396a047e4c30bafe3240953417"
-dependencies = [
- "ethereum-types 0.14.1",
- "tiny-keccak",
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -6320,8 +6180,8 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0",
- "polkadot-primitives 7.0.0",
+ "polkadot-parachain-primitives",
+ "polkadot-primitives",
  "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
@@ -7310,6 +7170,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7831,9 +7697,9 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8044,7 +7910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -8998,9 +8864,31 @@ dependencies = [
  "futures",
  "futures-timer",
  "getrandom 0.2.10",
- "libp2p-allow-block-list",
- "libp2p-connection-limits",
- "libp2p-core",
+ "instant",
+ "libp2p-allow-block-list 0.2.0",
+ "libp2p-connection-limits 0.2.1",
+ "libp2p-core 0.40.1",
+ "libp2p-identity",
+ "libp2p-swarm 0.43.7",
+ "multiaddr 0.18.1",
+ "pin-project",
+ "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "libp2p"
+version = "0.54.2"
+source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.10",
+ "libp2p-allow-block-list 0.4.2",
+ "libp2p-connection-limits 0.4.1",
+ "libp2p-core 0.42.1",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
@@ -9018,8 +8906,8 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr 0.18.1",
  "pin-project",
- "rw-stream-sink",
- "thiserror 1.0.65",
+ "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -9086,7 +8974,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf 0.8.1",
- "rand",
+ "rand 0.8.5",
  "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec",
  "thiserror 1.0.65",
@@ -9112,9 +9000,9 @@ dependencies = [
  "pin-project",
  "quick-protobuf 0.8.1",
  "rand 0.8.5",
- "rw-stream-sink",
+ "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -9152,7 +9040,7 @@ dependencies = [
  "quick-protobuf 0.8.1",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
 ]
 
@@ -9168,7 +9056,7 @@ dependencies = [
  "quick-protobuf 0.8.1",
  "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
  "zeroize",
 ]
@@ -9194,7 +9082,7 @@ dependencies = [
  "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
  "uint 0.9.5",
  "web-time",
@@ -9211,7 +9099,7 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.45.2",
  "rand 0.8.5",
  "smallvec",
  "socket2 0.5.8",
@@ -9255,7 +9143,7 @@ dependencies = [
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -9271,7 +9159,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.45.2",
  "rand 0.8.5",
  "tracing",
  "web-time",
@@ -9293,9 +9181,9 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.8",
- "rustls 0.23.18",
+ "rustls 0.23.14",
  "socket2 0.5.8",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tokio",
  "tracing",
 ]
@@ -9311,7 +9199,7 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm",
+ "libp2p-swarm 0.45.2",
  "rand 0.8.5",
  "smallvec",
  "tracing",
@@ -9334,7 +9222,7 @@ dependencies = [
  "log",
  "multistream-select 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "void",
 ]
@@ -9401,7 +9289,7 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.14",
  "rustls-webpki 0.101.4",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "x509-parser 0.16.0",
  "yasna",
 ]
@@ -9434,7 +9322,7 @@ dependencies = [
  "pin-project-lite",
  "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
  "soketto 0.8.0",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "tracing",
  "url",
  "webpki-roots 0.25.2",
@@ -9447,8 +9335,8 @@ source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c346
 dependencies = [
  "either",
  "futures",
- "libp2p-core",
- "thiserror 1.0.65",
+ "libp2p-core 0.42.1",
+ "thiserror 2.0.11",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.4",
@@ -10727,23 +10615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.5",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11302,7 +11173,7 @@ version = "4.0.0"
 dependencies = [
  "frame-election-provider-support",
  "honggfuzz",
- "pallet-bags-list 27.0.0",
+ "pallet-bags-list",
  "rand 0.8.5",
 ]
 
@@ -11584,32 +11455,12 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-consensus-aura 0.32.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "pallet-collator-selection"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658798d70c9054165169f6a6a96cfa9d6a5e7d24a524bc19825bf17fcbc5cc5a"
-dependencies = [
- "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "log",
- "pallet-authorship 38.0.0",
- "pallet-balances 39.0.0",
- "pallet-session 38.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-runtime 39.0.2",
- "sp-staking 36.0.0",
+ "sp-consensus-aura",
+ "sp-core 35.0.0",
+ "sp-io 39.0.0",
+ "sp-runtime 40.1.0",
+ "sp-staking",
+ "sp-tracing 17.0.1",
 ]
 
 [[package]]
@@ -11686,39 +11537,6 @@ dependencies = [
  "wasm-instrument",
  "wasmi 0.32.3",
  "wat",
-]
-
-[[package]]
-name = "pallet-contracts"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df77077745d891c822b4275f273f336077a97e69e62a30134776aa721c96fee"
-dependencies = [
- "bitflags 1.3.2",
- "environmental",
- "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-balances 39.0.0",
- "pallet-contracts-proc-macro 23.0.1",
- "pallet-contracts-uapi 12.0.0",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "smallvec",
- "sp-api 34.0.0",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.2",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.2.0",
- "staging-xcm-builder 17.0.1",
- "wasm-instrument",
- "wasmi 0.32.3",
 ]
 
 [[package]]
@@ -11913,33 +11731,11 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-tracing 16.0.0",
-]
-
-[[package]]
-name = "pallet-election-provider-multi-block"
-version = "0.9.0"
-dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "log",
- "pallet-balances 28.0.0",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "rand 0.8.5",
- "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 35.0.0",
+ "sp-io 39.0.0",
+ "sp-npos-elections",
+ "sp-runtime 40.1.0",
+ "sp-staking",
  "sp-std 14.0.0",
  "sp-tracing 17.0.1",
 ]
@@ -11957,30 +11753,6 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
- "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "pallet-election-provider-multi-phase"
-version = "37.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f9ad5ae0c13ba3727183dadf1825b6b7b0b0598ed5c366f8697e13fd540f7d"
-dependencies = [
- "frame-benchmarking 38.0.0",
- "frame-election-provider-support 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "log",
- "pallet-election-provider-support-benchmarking 37.0.0",
- "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
  "sp-arithmetic 26.0.0",
@@ -12575,11 +12347,11 @@ dependencies = [
  "frame-system",
  "honggfuzz",
  "log",
- "pallet-nomination-pools 25.0.0",
+ "pallet-nomination-pools",
  "rand 0.8.5",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
+ "sp-io 39.0.0",
+ "sp-runtime 40.1.0",
+ "sp-tracing 17.0.1",
 ]
 
 [[package]]
@@ -13077,206 +12849,6 @@ dependencies = [
  "sp-io 39.0.0",
  "sp-runtime 40.1.0",
  "sp-weights 31.0.0",
-]
-
-[[package]]
-name = "pallet-scored-pool"
-version = "28.0.0"
-dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-balances 28.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-scored-pool"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f84b48bb4702712c902f43931c4077d3a1cb6773c8d8c290d4a6251f6bc2a5c"
-dependencies = [
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-io 38.0.0",
- "sp-runtime 39.0.2",
-]
-
-[[package]]
-name = "pallet-session"
-version = "28.0.0"
-dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-timestamp 27.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-staking 26.0.0",
- "sp-state-machine 0.35.0",
- "sp-trie 29.0.0",
-]
-
-[[package]]
-name = "pallet-session"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8474b62b6b7622f891e83d922a589e2ad5be5471f5ca47d45831a797dba0b3f4"
-dependencies = [
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-timestamp 37.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-core 34.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.2",
- "sp-session 36.0.0",
- "sp-staking 36.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
-]
-
-[[package]]
-name = "pallet-session-benchmarking"
-version = "28.0.0"
-dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "pallet-balances 28.0.0",
- "pallet-session 28.0.0",
- "pallet-staking 28.0.0",
- "pallet-staking-reward-curve",
- "pallet-timestamp 27.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
-]
-
-[[package]]
-name = "pallet-session-benchmarking"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aadce7df0fee981721983795919642648b846dab5ab9096f82c2cea781007d0"
-dependencies = [
- "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "pallet-session 38.0.0",
- "pallet-staking 38.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "sp-runtime 39.0.2",
- "sp-session 36.0.0",
-]
-
-[[package]]
-name = "pallet-skip-feeless-payment"
-version = "3.0.0"
-dependencies = [
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-skip-feeless-payment"
-version = "13.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c2cb0dae13d2c2d2e76373f337d408468f571459df1900cbd7458f21cf6c01"
-dependencies = [
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 39.0.2",
-]
-
-[[package]]
-name = "pallet-society"
-version = "28.0.0"
-dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-support 28.0.0",
- "frame-support-test",
- "frame-system 28.0.0",
- "log",
- "pallet-balances 28.0.0",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "sp-arithmetic 23.0.0",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
-]
-
-[[package]]
-name = "pallet-society"
-version = "38.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1dc69fea8a8de343e71691f009d5fece6ae302ed82b7bb357882b2ea6454143"
-dependencies = [
- "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "log",
- "parity-scale-codec",
- "rand_chacha 0.3.1",
- "scale-info",
- "sp-arithmetic 26.0.0",
- "sp-io 38.0.0",
- "sp-runtime 39.0.2",
-]
-
-[[package]]
-name = "pallet-staking"
-version = "28.0.0"
-dependencies = [
- "frame-benchmarking 28.0.0",
- "frame-election-provider-support 28.0.0",
- "frame-support 28.0.0",
- "frame-system 28.0.0",
- "log",
- "pallet-authorship 28.0.0",
- "pallet-bags-list 27.0.0",
- "pallet-balances 28.0.0",
- "pallet-session 28.0.0",
- "pallet-staking-reward-curve",
- "pallet-timestamp 27.0.0",
- "parity-scale-codec",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
- "sp-staking 26.0.0",
- "sp-tracing 16.0.0",
  "substrate-test-utils",
 ]
 
@@ -13328,7 +12900,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-core 35.0.0",
  "sp-io 39.0.0",
@@ -13358,7 +12930,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 35.0.0",
@@ -13383,7 +12955,7 @@ dependencies = [
  "pallet-staking-reward-curve",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "scale-info",
  "serde",
  "sp-application-crypto 39.0.0",
@@ -13932,7 +13504,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
  "rand 0.8.5",
- "rand_core 0.6.4",
+ "rand_core 0.5.1",
  "serde",
  "unicode-normalization",
 ]
@@ -14594,15 +14166,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "sp-application-crypto 30.0.0",
- "sp-authority-discovery 26.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-authority-discovery",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-tracing 17.0.1",
  "tracing-gum",
 ]
 
@@ -14629,10 +14201,10 @@ dependencies = [
  "rstest",
  "sc-network",
  "schnellru",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-tracing 16.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14661,10 +14233,10 @@ dependencies = [
  "rstest",
  "sc-network",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tokio",
  "tracing-gum",
@@ -14730,11 +14302,11 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "schnellru",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-runtime 40.1.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tokio-util",
  "tracing-gum",
@@ -14774,10 +14346,10 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14792,8 +14364,8 @@ dependencies = [
  "polkadot-primitives",
  "quickcheck",
  "reed-solomon-novelpoly",
- "sp-core 28.0.0",
- "sp-trie 29.0.0",
+ "sp-core 35.0.0",
+ "sp-trie 38.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -14850,8 +14422,8 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "sc-network",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14912,13 +14484,13 @@ dependencies = [
  "schnorrkel 0.11.4",
  "sp-application-crypto 39.0.0",
  "sp-consensus",
- "sp-consensus-babe 0.32.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-runtime 40.1.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14954,13 +14526,13 @@ dependencies = [
  "schnorrkel 0.11.4",
  "sp-application-crypto 39.0.0",
  "sp-consensus",
- "sp-consensus-babe 0.32.0",
- "sp-consensus-slots 0.32.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
+ "sp-consensus-babe",
+ "sp-consensus-slots",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-runtime 40.1.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14987,9 +14559,9 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-tracing 16.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15014,11 +14586,11 @@ dependencies = [
  "rstest",
  "sc-keystore",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15033,7 +14605,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "sp-keystore 0.34.0",
+ "sp-keystore 0.41.0",
  "thiserror 1.0.65",
  "tracing-gum",
  "wasm-timer",
@@ -15102,8 +14674,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 7.0.0",
- "sp-core 28.0.0",
+ "polkadot-primitives",
+ "sp-core 35.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15127,11 +14699,11 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15147,7 +14719,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents 26.0.0",
+ "sp-inherents",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15166,8 +14738,8 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "rand 0.8.5",
  "rstest",
- "sp-core 28.0.0",
- "sp-tracing 16.0.0",
+ "sp-core 35.0.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15188,8 +14760,8 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "rstest",
  "schnellru",
- "sp-application-crypto 30.0.0",
- "sp-keystore 0.34.0",
+ "sp-application-crypto 39.0.0",
+ "sp-keystore 0.41.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15253,11 +14825,11 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 39.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -15392,7 +14964,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-authority-discovery",
@@ -15425,7 +14997,7 @@ dependencies = [
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
  "sp-maybe-compressed-blob 11.0.0",
- "sp-runtime 31.0.1",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
  "zstd 0.12.4",
 ]
@@ -15716,69 +15288,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-primitives"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57bc055fa389372ec5fc0001b99aeffd50f3fd379280ce572d935189bb58dd8"
-dependencies = [
- "bitvec",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
- "scale-info",
- "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
- "sp-authority-discovery 34.0.0",
- "sp-consensus-slots 0.40.1",
- "sp-core 34.0.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
- "sp-staking 34.0.0",
-]
-
-[[package]]
-name = "polkadot-primitives"
-version = "16.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb20b75d33212150242d39890d7ededab55f1084160c337f15d0eb8ca8c3ad4"
-dependencies = [
- "bitvec",
- "hex-literal",
- "log",
- "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
- "scale-info",
- "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
- "sp-authority-discovery 34.0.0",
- "sp-consensus-slots 0.40.1",
- "sp-core 34.0.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
- "sp-staking 36.0.0",
-]
-
-[[package]]
 name = "polkadot-primitives-test-helpers"
 version = "0.1.0"
 dependencies = [
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
  "rand 0.8.5",
- "sp-application-crypto 30.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-runtime 31.0.1",
+ "sp-application-crypto 39.0.0",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-runtime 40.1.0",
 ]
 
 [[package]]
@@ -15913,7 +15431,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "polkadot-runtime-metrics 7.0.0",
+ "polkadot-runtime-metrics",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rstest",
@@ -15939,55 +15457,6 @@ dependencies = [
  "staging-xcm-executor",
  "static_assertions",
  "thousands",
-]
-
-[[package]]
-name = "polkadot-runtime-parachains"
-version = "17.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd58e3a17e5df678f5737b018cbfec603af2c93bec56bbb9f8fb8b2b017b54b1"
-dependencies = [
- "bitflags 1.3.2",
- "bitvec",
- "derive_more 0.99.17",
- "frame-benchmarking 38.0.0",
- "frame-support 38.0.0",
- "frame-system 38.0.0",
- "impl-trait-for-tuples",
- "log",
- "pallet-authority-discovery 38.0.0",
- "pallet-authorship 38.0.0",
- "pallet-babe 38.0.0",
- "pallet-balances 39.0.0",
- "pallet-broker 0.17.0",
- "pallet-message-queue 41.0.1",
- "pallet-mmr 38.0.0",
- "pallet-session 38.0.0",
- "pallet-staking 38.0.0",
- "pallet-timestamp 37.0.0",
- "pallet-vesting 38.0.0",
- "parity-scale-codec",
- "polkadot-core-primitives 15.0.0",
- "polkadot-parachain-primitives 14.0.0",
- "polkadot-primitives 16.0.0",
- "polkadot-runtime-metrics 17.0.0",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "scale-info",
- "serde",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
- "sp-core 34.0.0",
- "sp-inherents 34.0.0",
- "sp-io 38.0.0",
- "sp-keystore 0.40.0",
- "sp-runtime 39.0.2",
- "sp-session 36.0.0",
- "sp-staking 36.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "staging-xcm 14.2.0",
- "staging-xcm-executor 17.0.0",
 ]
 
 [[package]]
@@ -16427,7 +15896,7 @@ dependencies = [
  "polkadot-sdk",
  "polkadot-sdk-docs-first-pallet",
  "polkadot-sdk-docs-first-runtime",
- "polkadot-sdk-frame 0.1.0",
+ "polkadot-sdk-frame",
  "rand 0.8.5",
  "sc-chain-spec",
  "sc-cli",
@@ -16676,13 +16145,13 @@ dependencies = [
  "rstest",
  "sc-keystore",
  "sc-network",
- "sp-application-crypto 30.0.0",
- "sp-authority-discovery 26.0.0",
- "sp-core 28.0.0",
- "sp-keyring 31.0.0",
- "sp-keystore 0.34.0",
- "sp-staking 26.0.0",
- "sp-tracing 16.0.0",
+ "sp-application-crypto 39.0.0",
+ "sp-authority-discovery",
+ "sp-core 35.0.0",
+ "sp-keyring",
+ "sp-keystore 0.41.0",
+ "sp-staking",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -16825,10 +16294,10 @@ dependencies = [
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
- "polkadot-primitives 7.0.0",
+ "polkadot-primitives",
  "rand 0.8.5",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
+ "sp-core 35.0.0",
+ "sp-keystore 0.41.0",
  "substrate-build-script-utils",
  "tracing-gum",
 ]
@@ -17718,7 +17187,7 @@ dependencies = [
  "log",
  "names",
  "prost 0.11.9",
- "reqwest 0.11.27",
+ "reqwest 0.11.20",
  "thiserror 1.0.65",
  "url",
  "winapi",
@@ -17784,7 +17253,7 @@ dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf 0.8.1",
- "thiserror 1.0.65",
+ "thiserror 2.0.11",
  "unsigned-varint 0.8.0",
 ]
 
@@ -17822,7 +17291,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.18",
+ "rustls 0.23.14",
  "socket2 0.5.8",
  "thiserror 1.0.65",
  "tokio",
@@ -18257,9 +17726,9 @@ dependencies = [
  "sp-rpc",
  "sp-runtime 40.1.0",
  "sp-std 14.0.0",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "staging-xcm 7.0.0",
+ "sp-trie 38.0.0",
+ "sp-version 38.0.0",
+ "staging-xcm",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -19163,23 +18632,13 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "23.0.0"
-dependencies = [
- "log",
- "sp-core 28.0.0",
- "sp-wasm-interface 20.0.0",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sc-allocator"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f01218e73ea57916be5f08987995ac802d6f4ede4ea5ce0242e468c590e4e2"
 dependencies = [
  "log",
  "sp-core 33.0.1",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface 21.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -19397,6 +18856,7 @@ dependencies = [
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "quickcheck",
  "rand 0.8.5",
  "sc-client-api",
  "sc-state-db",
@@ -19830,9 +19290,19 @@ dependencies = [
  "sp-externalities 0.30.0",
  "sp-io 39.0.0",
  "sp-maybe-compressed-blob 11.0.0",
- "sp-wasm-interface 20.0.0",
- "thiserror 1.0.65",
- "wasm-instrument",
+ "sp-panic-handler 13.0.1",
+ "sp-runtime 40.1.0",
+ "sp-runtime-interface 29.0.0",
+ "sp-state-machine 0.44.0",
+ "sp-tracing 17.0.1",
+ "sp-trie 38.0.0",
+ "sp-version 38.0.0",
+ "sp-wasm-interface 21.0.1",
+ "substrate-test-runtime",
+ "tempfile",
+ "tracing",
+ "tracing-subscriber 0.3.18",
+ "wat",
 ]
 
 [[package]]
@@ -19844,7 +19314,7 @@ dependencies = [
  "polkavm 0.9.3",
  "sc-allocator 28.0.0",
  "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface 21.0.0",
  "thiserror 1.0.65",
  "wasm-instrument",
 ]
@@ -19977,10 +19447,10 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api 35.0.0",
  "sp-consensus",
- "sp-core 28.0.0",
- "sp-keystore 0.34.0",
- "sp-mixnet 0.4.0",
- "sp-runtime 31.0.1",
+ "sp-core 35.0.0",
+ "sp-keystore 0.41.0",
+ "sp-mixnet",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -20106,8 +19576,8 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 35.0.0",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -20256,7 +19726,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "rand 0.8.5",
- "rustls 0.23.18",
+ "rustls 0.23.14",
  "sc-block-builder",
  "sc-client-api",
  "sc-client-db",
@@ -20342,8 +19812,8 @@ dependencies = [
  "serde_json",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
- "sp-version 29.0.0",
+ "sp-runtime 40.1.0",
+ "sp-version 38.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -20418,30 +19888,11 @@ dependencies = [
 name = "sc-runtime-test"
 version = "2.0.0"
 dependencies = [
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "substrate-wasm-builder 17.0.0",
-]
-
-[[package]]
-name = "sc-runtime-utilities"
-version = "0.1.0"
-dependencies = [
- "cumulus-primitives-proof-size-hostfunction 0.2.0",
- "cumulus-test-runtime",
- "parity-scale-codec",
- "sc-executor 0.32.0",
- "sc-executor-common 0.29.0",
- "sp-core 28.0.0",
- "sp-crypto-hashing 0.1.0",
- "sp-io 30.0.0",
- "sp-state-machine 0.35.0",
- "sp-version 29.0.0",
- "sp-wasm-interface 20.0.0",
- "subxt",
- "thiserror 1.0.65",
+ "sp-core 35.0.0",
+ "sp-io 39.0.0",
+ "sp-runtime 40.1.0",
+ "sp-runtime-interface 29.0.0",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -20582,7 +20033,7 @@ dependencies = [
  "clap 4.5.13",
  "fs4",
  "log",
- "sp-core 28.0.0",
+ "sp-core 35.0.0",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -20601,7 +20052,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 31.0.1",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -20637,6 +20088,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "rand 0.8.5",
+ "sc-network",
  "sc-utils",
  "serde",
  "serde_json",
@@ -20665,8 +20117,8 @@ dependencies = [
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 31.0.1",
- "sp-tracing 16.0.0",
+ "sp-runtime 40.1.0",
+ "sp-tracing 17.0.1",
  "thiserror 1.0.65",
  "tracing",
  "tracing-log 0.2.0",
@@ -20727,14 +20179,13 @@ version = "38.0.0"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.7.1",
  "log",
  "parity-scale-codec",
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-runtime 31.0.1",
+ "sp-core 35.0.0",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -20864,7 +20315,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "scale-info",
- "syn 2.0.98",
+ "syn 2.0.87",
  "thiserror 1.0.65",
 ]
 
@@ -21026,18 +20477,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "secp256k1-sys 0.9.2",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
-dependencies = [
- "bitcoin_hashes 0.14.0",
- "rand 0.8.5",
- "secp256k1-sys 0.10.1",
+ "secp256k1-sys",
 ]
 
 [[package]]
@@ -21617,7 +21057,7 @@ dependencies = [
  "poly1305",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "ruzstd 0.6.0",
+ "ruzstd 0.5.0",
  "schnorrkel 0.11.4",
  "serde",
  "serde_json",
@@ -22166,43 +21606,21 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 26.0.0",
- "sp-block-builder 26.0.0",
- "sp-consensus-aura 0.32.0",
- "sp-consensus-grandpa 13.0.0",
- "sp-core 28.0.0",
- "sp-genesis-builder 0.8.0",
- "sp-inherents 26.0.0",
- "sp-keyring 31.0.0",
- "sp-offchain 26.0.0",
- "sp-runtime 31.0.1",
- "sp-session 27.0.0",
- "sp-storage 19.0.0",
- "sp-transaction-pool 26.0.0",
- "sp-version 29.0.0",
- "substrate-wasm-builder 17.0.0",
-]
-
-[[package]]
-name = "sp-api"
-version = "26.0.0"
-dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 15.0.0",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-metadata-ir 0.6.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
- "sp-state-machine 0.35.0",
- "sp-test-primitives",
- "sp-trie 29.0.0",
- "sp-version 29.0.0",
- "thiserror 1.0.65",
+ "sp-api 35.0.0",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-grandpa",
+ "sp-core 35.0.0",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime 40.1.0",
+ "sp-session",
+ "sp-storage 22.0.0",
+ "sp-transaction-pool",
+ "sp-version 38.0.0",
+ "substrate-wasm-builder",
 ]
 
 [[package]]
@@ -22237,30 +21655,17 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 20.0.0",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-metadata-ir 0.7.0",
- "sp-runtime 39.0.2",
- "sp-runtime-interface 28.0.0",
- "sp-state-machine 0.43.0",
- "sp-trie 37.0.0",
- "sp-version 37.0.0",
+ "sp-api-proc-macro 21.0.0",
+ "sp-core 35.0.0",
+ "sp-externalities 0.30.0",
+ "sp-metadata-ir 0.8.0",
+ "sp-runtime 40.1.0",
+ "sp-runtime-interface 29.0.0",
+ "sp-state-machine 0.44.0",
+ "sp-test-primitives",
+ "sp-trie 38.0.0",
+ "sp-version 38.0.0",
  "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "15.0.0"
-dependencies = [
- "Inflector",
- "assert_matches",
- "blake2 0.10.6",
- "expander",
- "proc-macro-crate 3.1.0",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -22470,8 +21875,8 @@ dependencies = [
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-database",
- "sp-runtime 31.0.1",
- "sp-state-machine 0.35.0",
+ "sp-runtime 40.1.0",
+ "sp-state-machine 0.44.0",
  "thiserror 1.0.65",
  "tracing",
 ]
@@ -22606,9 +22011,8 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
- "primitive-types 0.13.1",
+ "primitive-types 0.12.2",
  "rand 0.8.5",
- "regex",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -22621,7 +22025,7 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 20.0.0",
  "ss58-registry",
- "substrate-bip39 0.4.7",
+ "substrate-bip39 0.5.0",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -22668,7 +22072,7 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -22715,54 +22119,7 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0",
- "thiserror 1.0.65",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
-dependencies = [
- "array-bytes",
- "bitflags 1.3.2",
- "blake2 0.10.6",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra 4.0.3",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde 0.4.0",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot 0.12.3",
- "paste",
- "primitive-types 0.12.2",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel 0.11.4",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
- "serde",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.29.0",
- "sp-runtime-interface 28.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-storage 21.0.0",
- "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -22796,6 +22153,7 @@ dependencies = [
  "paste",
  "primitive-types 0.13.1",
  "rand 0.8.5",
+ "regex",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -22986,21 +22344,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afffbddc380d99a90c459ba1554bbbc01d62e892de9f1485af6940b89c4c0d57"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 39.0.2",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -23127,10 +22471,8 @@ checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
+ "sp-core 31.0.0",
+ "sp-externalities 0.27.0",
 ]
 
 [[package]]
@@ -23163,8 +22505,8 @@ version = "0.41.0"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sp-core 35.0.0",
  "sp-externalities 0.30.0",
 ]
@@ -23230,25 +22572,7 @@ dependencies = [
  "sp-api 35.0.0",
  "sp-core 35.0.0",
  "sp-debug-derive 14.0.0",
- "sp-runtime 31.0.1",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sp-mmr-primitives"
-version = "34.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a12dd76e368f1e48144a84b4735218b712f84b3f976970e2f25a29b30440e10"
-dependencies = [
- "log",
- "parity-scale-codec",
- "polkadot-ckb-merkle-mountain-range 0.7.0",
- "scale-info",
- "serde",
- "sp-api 34.0.0",
- "sp-core 34.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 39.0.2",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -23273,8 +22597,8 @@ dependencies = [
  "clap 4.5.13",
  "honggfuzz",
  "rand 0.8.5",
- "sp-npos-elections 26.0.0",
- "sp-runtime 31.0.1",
+ "sp-npos-elections",
+ "sp-runtime 40.1.0",
 ]
 
 [[package]]
@@ -23587,14 +22911,13 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "pretty_assertions",
  "rand 0.8.5",
  "smallvec",
  "sp-core 31.0.0",
  "sp-externalities 0.27.0",
  "sp-panic-handler 13.0.0",
- "sp-runtime 31.0.1",
- "sp-trie 29.0.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 32.0.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.28.0",
@@ -23653,12 +22976,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
+ "pretty_assertions",
  "rand 0.8.5",
  "smallvec",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
- "sp-panic-handler 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 37.0.0",
+ "sp-core 35.0.0",
+ "sp-externalities 0.30.0",
+ "sp-panic-handler 13.0.1",
+ "sp-runtime 40.1.0",
+ "sp-trie 38.0.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.29.1",
@@ -23680,42 +23005,12 @@ dependencies = [
  "sp-application-crypto 39.0.0",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0",
- "sp-externalities 0.25.0",
- "sp-runtime 31.0.1",
- "sp-runtime-interface 24.0.0",
+ "sp-externalities 0.30.0",
+ "sp-runtime 40.1.0",
+ "sp-runtime-interface 29.0.0",
  "thiserror 1.0.65",
  "x25519-dalek",
 ]
-
-[[package]]
-name = "sp-statement-store"
-version = "18.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c219bc34ef4d1f9835f3ed881f965643c32034fcc030eb33b759dadbc802c1c2"
-dependencies = [
- "aes-gcm",
- "curve25519-dalek 4.1.3",
- "ed25519-dalek",
- "hkdf",
- "parity-scale-codec",
- "rand 0.8.5",
- "scale-info",
- "sha2 0.10.8",
- "sp-api 34.0.0",
- "sp-application-crypto 38.0.0",
- "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-externalities 0.29.0",
- "sp-runtime 39.0.2",
- "sp-runtime-interface 28.0.0",
- "thiserror 1.0.65",
- "x25519-dalek",
-]
-
-[[package]]
-name = "sp-std"
-version = "8.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
 
 [[package]]
 name = "sp-std"
@@ -23783,21 +23078,8 @@ version = "35.0.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents 26.0.0",
- "sp-runtime 31.0.1",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "34.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a1cb4df653d62ccc0dbce1db45d1c9443ec60247ee9576962d24da4c9c6f07"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents 34.0.0",
- "sp-runtime 39.0.2",
+ "sp-inherents",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
 ]
 
@@ -23873,9 +23155,9 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 28.0.0",
- "sp-externalities 0.25.0",
- "sp-runtime 31.0.1",
+ "sp-core 31.0.0",
+ "sp-externalities 0.27.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.28.0",
@@ -23945,29 +23227,15 @@ dependencies = [
  "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 34.0.0",
- "sp-externalities 0.29.0",
+ "sp-core 35.0.0",
+ "sp-externalities 0.30.0",
+ "sp-runtime 40.1.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-bench",
  "trie-db 0.29.1",
  "trie-root",
-]
-
-[[package]]
-name = "sp-version"
-version = "29.0.0"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro 0.1.0",
- "sp-runtime 31.0.1",
- "sp-std 14.0.0",
- "sp-version-proc-macro 13.0.0",
- "thiserror 1.0.65",
+ "trie-standardmap",
 ]
 
 [[package]]
@@ -23997,23 +23265,11 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-runtime 39.0.2",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-version-proc-macro 14.0.0",
+ "sp-crypto-hashing-proc-macro 0.1.0",
+ "sp-runtime 40.1.0",
+ "sp-std 14.0.0",
+ "sp-version-proc-macro 15.0.0",
  "thiserror 1.0.65",
-]
-
-[[package]]
-name = "sp-version-proc-macro"
-version = "13.0.0"
-dependencies = [
- "parity-scale-codec",
- "proc-macro-warning",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "sp-version 29.0.0",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -24157,210 +23413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
-name = "sqlx"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
-dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
-]
-
-[[package]]
-name = "sqlx-core"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
-dependencies = [
- "atoi",
- "byteorder",
- "bytes",
- "crc",
- "crossbeam-queue",
- "either",
- "event-listener 5.3.1",
- "futures-channel",
- "futures-core",
- "futures-intrusive",
- "futures-io",
- "futures-util",
- "hashbrown 0.14.5",
- "hashlink 0.9.1",
- "hex",
- "indexmap 2.7.1",
- "log",
- "memchr",
- "once_cell",
- "paste",
- "percent-encoding",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "smallvec",
- "sqlformat",
- "thiserror 1.0.65",
- "tokio",
- "tokio-stream",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "sqlx-macros"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
-dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "sqlx-core",
- "sqlx-macros-core",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "sqlx-macros-core"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
-dependencies = [
- "dotenvy",
- "either",
- "heck 0.5.0",
- "hex",
- "once_cell",
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
- "syn 2.0.98",
- "tempfile",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "sqlx-mysql"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags 2.6.0",
- "byteorder",
- "bytes",
- "crc",
- "digest 0.10.7",
- "dotenvy",
- "either",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "generic-array 0.14.7",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "percent-encoding",
- "rand 0.8.5",
- "rsa",
- "serde",
- "sha1",
- "sha2 0.10.8",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 1.0.65",
- "tracing",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-postgres"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
-dependencies = [
- "atoi",
- "base64 0.22.1",
- "bitflags 2.6.0",
- "byteorder",
- "crc",
- "dotenvy",
- "etcetera",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-util",
- "hex",
- "hkdf",
- "hmac 0.12.1",
- "home",
- "itoa",
- "log",
- "md-5",
- "memchr",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "smallvec",
- "sqlx-core",
- "stringprep",
- "thiserror 1.0.65",
- "tracing",
- "whoami",
-]
-
-[[package]]
-name = "sqlx-sqlite"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
-dependencies = [
- "atoi",
- "flume",
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-intrusive",
- "futures-util",
- "libsqlite3-sys",
- "log",
- "percent-encoding",
- "serde",
- "serde_urlencoded",
- "sqlx-core",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "ss58-registry"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24468,10 +23520,10 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core 28.0.0",
- "sp-io 30.0.0",
- "sp-runtime 31.0.1",
- "sp-statement-store 10.0.0",
+ "sp-core 35.0.0",
+ "sp-io 39.0.0",
+ "sp-runtime 40.1.0",
+ "sp-statement-store",
  "thiserror 1.0.65",
 ]
 
@@ -24933,7 +23985,7 @@ dependencies = [
  "sp-core 32.0.0",
  "sp-io 35.0.0",
  "sp-runtime 36.0.0",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface 21.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -25134,7 +24186,7 @@ dependencies = [
  "log",
  "num-format",
  "rand 0.8.5",
- "reqwest 0.12.9",
+ "reqwest 0.12.5",
  "scale-info",
  "semver 1.0.18",
  "serde",
@@ -25179,7 +24231,6 @@ dependencies = [
  "subxt-macro",
  "subxt-metadata",
  "thiserror 1.0.65",
- "tokio",
  "tokio-util",
  "tracing",
  "url",
@@ -25201,8 +24252,9 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.98",
+ "syn 2.0.87",
  "thiserror 1.0.65",
+ "tokio",
 ]
 
 [[package]]
@@ -25244,7 +24296,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light 0.16.2",
+ "smoldot-light 0.14.0",
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
@@ -25301,17 +24353,6 @@ dependencies = [
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
  "zeroize",
-]
-
-[[package]]
-name = "subxt-utils-fetchmetadata"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082b17a86e3c3fe45d858d94d68f6b5247caace193dad6201688f24db8ba9bb"
-dependencies = [
- "hex",
- "parity-scale-codec",
- "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -25795,24 +24836,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.37",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "thiserror-impl"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -26085,7 +25115,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.18",
+ "rustls 0.23.14",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -26157,6 +25187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.7.1",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -26532,7 +25564,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.0",
- "rustls 0.23.18",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.11",
@@ -26908,12 +25940,6 @@ checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
 dependencies = [
  "wit-bindgen-rt",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -27974,6 +27000,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28335,9 +27371,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
  "synstructure 0.13.1",
 ]
 
@@ -28376,9 +27412,9 @@ version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -28396,9 +27432,9 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
  "synstructure 0.13.1",
 ]
 
@@ -28439,9 +27475,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
- "proc-macro2 1.0.93",
- "quote 1.0.38",
- "syn 2.0.98",
+ "proc-macro2 1.0.86",
+ "quote 1.0.37",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -28581,10 +27617,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "nix 0.29.0",
+ "nix 0.27.1",
  "rand 0.8.5",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.11.20",
  "thiserror 1.0.65",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
 ]
@@ -104,10 +104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.32",
 ]
 
 [[package]]
@@ -139,9 +139,37 @@ dependencies = [
  "hex-literal",
  "itoa",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "ruint",
  "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6259a506ab13e1d658796c31e6e39d2e2ee89243bcc505ddc613b35732e0a430"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "hex-literal",
+ "indexmap 2.7.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "rustc-hash 2.0.0",
+ "serde",
+ "sha3 0.10.8",
  "tiny-keccak",
 ]
 
@@ -171,6 +199,63 @@ dependencies = [
  "syn 2.0.87",
  "syn-solidity",
  "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9d64f851d95619233f74b310f12bcf16e0cbc27ee3762b6115c14a84809280a"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error2",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf7ed1574b699f48bf17caab4e6e54c6d12bc3c006ab33d58b1e227c1c3559f"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.7.1",
+ "proc-macro-error2",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+ "syn-solidity 0.8.15",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c02997ccef5f34f9c099277d4145f183b422938ed5322dc57a089fe9b9ad9ee"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+ "syn-solidity 0.8.15",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce13ff37285b0870d0a0746992a4ae48efaf34b766ae4c2640fa15e5305f8e73"
+dependencies = [
+ "serde",
+ "winnow 0.6.18",
 ]
 
 [[package]]
@@ -612,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -622,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rayon",
 ]
 
@@ -665,13 +750,29 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.0",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
  "num-traits",
  "rusticata-macros",
  "thiserror 1.0.65",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "607495ec7113b178fbba7a6166a27f99e774359ef4823adbefd756b5b81d7970"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -684,6 +785,18 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.87",
+ "synstructure 0.13.1",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
  "synstructure 0.13.1",
 ]
 
@@ -1410,9 +1523,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1428,6 +1541,27 @@ dependencies = [
  "miniz_oxide",
  "object 0.32.2",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bandersnatch_vrfs"
+version = "0.0.4"
+source = "git+https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266d851932ad25d6b41bc4b34d834d1e11d"
+dependencies = [
+ "ark-bls12-381",
+ "ark-ec",
+ "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "dleq_vrf",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "ring 0.1.0",
+ "sha2 0.10.8",
+ "sp-ark-bls12-381",
+ "sp-ark-ed-on-bls12-381-bandersnatch",
+ "zeroize",
 ]
 
 [[package]]
@@ -2563,9 +2697,12 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bzip2-sys"
@@ -3030,7 +3167,7 @@ checksum = "a90d114103adbc625300f346d4d09dfb4ab1c4a8df6868435dd903392ecf4354"
 dependencies = [
  "libc",
  "once_cell",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -3237,6 +3374,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "common"
+version = "0.1.0"
+source = "git+https://github.com/w3f/ring-proof?rev=665f5f5#665f5f51af5734c7b6d90b985dd6861d4c5b4752"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-poly",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "fflonk",
+ "getrandom_or_panic",
+ "merlin",
+ "rand_chacha 0.3.1",
+]
+
+[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3345,7 +3498,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "once_cell",
  "proc-macro-hack",
  "tiny-keccak",
@@ -4102,9 +4255,9 @@ dependencies = [
  "async-trait",
  "cumulus-primitives-parachain-inherent",
  "sp-consensus",
- "sp-inherents",
- "sp-runtime 40.1.0",
- "sp-state-machine 0.44.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
  "thiserror 1.0.65",
 ]
 
@@ -4204,9 +4357,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
- "portpicker",
- "rand",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
  "rstest",
  "sc-cli",
  "sc-client-api",
@@ -4317,10 +4469,9 @@ dependencies = [
  "log",
  "pallet-message-queue",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-runtime-common",
- "polkadot-runtime-parachains",
- "rand",
+ "polkadot-parachain-primitives 6.0.0",
+ "polkadot-runtime-parachains 7.0.0",
+ "rand 0.8.5",
  "sc-client-api",
  "scale-info",
  "sp-consensus-slots",
@@ -4583,8 +4734,8 @@ dependencies = [
  "sc-client-api",
  "sp-api 35.0.0",
  "sp-blockchain",
- "sp-state-machine 0.44.0",
- "sp-version 38.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-version 29.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -4638,7 +4789,7 @@ dependencies = [
  "polkadot-overseer",
  "portpicker",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -4796,7 +4947,7 @@ dependencies = [
  "polkadot-test-service",
  "portpicker",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "sc-basic-authorship",
  "sc-block-builder",
  "sc-chain-spec",
@@ -4848,7 +4999,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "windows-sys 0.52.0",
 ]
 
@@ -5099,7 +5250,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.1",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.0",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -5673,8 +5838,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
- "cc",
- "libc",
+ "ethereum-types 0.14.1",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3 0.10.8",
+ "thiserror 1.0.65",
+ "uint 0.9.5",
+]
+
+[[package]]
+name = "ethabi-decode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d398648d65820a727d6a81e58b962f874473396a047e4c30bafe3240953417"
+dependencies = [
+ "ethereum-types 0.14.1",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -5855,7 +6037,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb42427514b063d97ce21d5199f36c0c307d981434a6be32582bc79fe5bd2303"
 dependencies = [
  "expander",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "proc-macro-crate 3.1.0",
  "proc-macro2 1.0.86",
  "quote 1.0.37",
@@ -5949,7 +6131,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
 ]
 
@@ -5997,7 +6179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -6138,9 +6320,9 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "polkadot-parachain-primitives",
- "polkadot-primitives",
- "rand",
+ "polkadot-parachain-primitives 6.0.0",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
  "rand_pcg",
  "sc-block-builder",
  "sc-chain-spec",
@@ -6217,7 +6399,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 35.0.0",
@@ -6236,7 +6418,7 @@ dependencies = [
  "frame-support",
  "honggfuzz",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-npos-elections",
@@ -6827,7 +7009,19 @@ checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6836,7 +7030,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
 ]
 
@@ -6998,7 +7192,7 @@ dependencies = [
  "nonzero_ext",
  "parking_lot 0.12.3",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
 ]
 
@@ -7025,7 +7219,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.9",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -7044,7 +7238,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -7194,8 +7388,8 @@ dependencies = [
  "idna 0.4.0",
  "ipnet",
  "once_cell",
- "rand",
- "socket2 0.5.7",
+ "rand 0.8.5",
+ "socket2 0.5.8",
  "thiserror 1.0.65",
  "tinyvec",
  "tokio",
@@ -7216,7 +7410,7 @@ dependencies = [
  "lru-cache",
  "once_cell",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "resolv-conf",
  "smallvec",
  "thiserror 1.0.65",
@@ -7392,7 +7586,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -7494,7 +7688,7 @@ dependencies = [
  "http-body 1.0.0",
  "hyper 1.3.1",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower",
  "tower-service",
@@ -7525,6 +7719,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7542,12 +7854,23 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -7594,7 +7917,7 @@ dependencies = [
  "hyper 1.3.1",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "tokio",
  "url",
  "xmltree",
@@ -7716,9 +8039,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -7793,7 +8116,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
 dependencies = [
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "widestring",
  "windows-sys 0.48.0",
  "winreg 0.50.0",
@@ -8175,7 +8498,7 @@ dependencies = [
  "jsonrpsee-types 0.24.3",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 2.0.0",
  "serde",
  "serde_json",
@@ -8462,7 +8785,7 @@ dependencies = [
  "kube-core",
  "pem 3.0.4",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "rustls 0.21.7",
  "rustls-pemfile 1.0.3",
  "secrecy",
@@ -8471,7 +8794,7 @@ dependencies = [
  "serde_yaml",
  "thiserror 1.0.65",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tokio-util",
  "tower",
  "tower-http 0.4.4",
@@ -8674,32 +8997,10 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom",
- "instant",
- "libp2p-allow-block-list 0.2.0",
- "libp2p-connection-limits 0.2.1",
- "libp2p-core 0.40.1",
- "libp2p-identity",
- "libp2p-swarm 0.43.7",
- "multiaddr 0.18.1",
- "pin-project",
- "rw-stream-sink 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "thiserror 1.0.65",
-]
-
-[[package]]
-name = "libp2p"
-version = "0.54.2"
-source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48#04c2e649b1f5482b8c3466b0fdbd1815b3126a48"
-dependencies = [
- "bytes",
- "either",
- "futures",
- "futures-timer",
- "getrandom",
- "libp2p-allow-block-list 0.4.2",
- "libp2p-connection-limits 0.4.1",
- "libp2p-core 0.42.1",
+ "getrandom 0.2.10",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
  "libp2p-dns",
  "libp2p-identify",
  "libp2p-identity",
@@ -8717,8 +9018,8 @@ dependencies = [
  "libp2p-yamux",
  "multiaddr 0.18.1",
  "pin-project",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
- "thiserror 2.0.12",
+ "rw-stream-sink",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -8810,10 +9111,10 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project",
  "quick-protobuf 0.8.1",
- "rand",
- "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
+ "rand 0.8.5",
+ "rw-stream-sink",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -8851,7 +9152,7 @@ dependencies = [
  "quick-protobuf 0.8.1",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
 ]
 
@@ -8865,9 +9166,9 @@ dependencies = [
  "hkdf",
  "multihash 0.19.1",
  "quick-protobuf 0.8.1",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
  "zeroize",
 ]
@@ -8890,10 +9191,10 @@ dependencies = [
  "libp2p-swarm 0.45.2",
  "quick-protobuf 0.8.1",
  "quick-protobuf-codec",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "smallvec",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
  "uint 0.9.5",
  "web-time",
@@ -8910,10 +9211,10 @@ dependencies = [
  "if-watch",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "smallvec",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -8950,11 +9251,11 @@ dependencies = [
  "multihash 0.19.1",
  "once_cell",
  "quick-protobuf 0.8.1",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -8970,8 +9271,8 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "tracing",
  "web-time",
 ]
@@ -8990,11 +9291,11 @@ dependencies = [
  "libp2p-tls",
  "parking_lot 0.12.3",
  "quinn",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.8",
- "rustls 0.23.14",
- "socket2 0.5.7",
- "thiserror 2.0.12",
+ "rustls 0.23.18",
+ "socket2 0.5.8",
+ "thiserror 1.0.65",
  "tokio",
  "tracing",
 ]
@@ -9010,8 +9311,8 @@ dependencies = [
  "futures-timer",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "libp2p-swarm 0.45.2",
- "rand",
+ "libp2p-swarm",
+ "rand 0.8.5",
  "smallvec",
  "tracing",
  "web-time",
@@ -9053,7 +9354,7 @@ dependencies = [
  "lru 0.12.3",
  "multistream-select 0.13.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "tokio",
  "tracing",
@@ -9082,7 +9383,7 @@ dependencies = [
  "libc",
  "libp2p-core 0.42.1",
  "libp2p-identity",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tracing",
 ]
@@ -9100,8 +9401,8 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.14",
  "rustls-webpki 0.101.4",
- "thiserror 2.0.12",
- "x509-parser",
+ "thiserror 1.0.65",
+ "x509-parser 0.16.0",
  "yasna",
 ]
 
@@ -9133,7 +9434,7 @@ dependencies = [
  "pin-project-lite",
  "rw-stream-sink 0.4.0 (git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c3466b0fdbd1815b3126a48)",
  "soketto 0.8.0",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "tracing",
  "url",
  "webpki-roots 0.25.2",
@@ -9146,8 +9447,8 @@ source = "git+https://github.com/autonomys/rust-libp2p?rev=04c2e649b1f5482b8c346
 dependencies = [
  "either",
  "futures",
- "libp2p-core 0.42.1",
- "thiserror 2.0.12",
+ "libp2p-core",
+ "thiserror 1.0.65",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.4",
@@ -9181,7 +9482,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -9310,10 +9611,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "litep2p"
-version = "0.9.0"
+name = "litemap"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca6ee50a125dc4fc4e9a3ae3640010796d1d07bc517a0ac715fdf0b24a0b6ac"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litep2p"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5a3d13ee6af6f01bb2093aa6d5f29b79ede7de6277e5d0394e8f5d8eaa5a86"
 dependencies = [
  "async-trait",
  "bs58",
@@ -9324,18 +9631,17 @@ dependencies = [
  "futures-timer",
  "hex-literal",
  "hickory-resolver",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "libc",
- "mockall 0.13.0",
+ "mockall 0.13.1",
  "multiaddr 0.17.1",
  "multihash 0.17.0",
  "network-interface",
- "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "rcgen 0.10.0",
  "ring 0.16.20",
  "rustls 0.20.9",
@@ -9344,19 +9650,19 @@ dependencies = [
  "simple-dns",
  "smallvec",
  "snow",
- "socket2 0.5.7",
- "static_assertions",
- "thiserror 1.0.65",
+ "socket2 0.5.8",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.26.2",
  "tokio-util",
  "tracing",
- "uint 0.9.5",
+ "uint 0.10.0",
  "unsigned-varint 0.8.0",
  "url",
  "x25519-dalek",
- "x509-parser",
+ "x509-parser 0.17.0",
+ "yamux 0.13.4",
  "yasna",
  "zeroize",
 ]
@@ -9708,7 +10014,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -9729,8 +10035,8 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.3",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.5.0",
  "thiserror 1.0.65",
@@ -9792,14 +10098,14 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "mockall_derive 0.13.0",
+ "mockall_derive 0.13.1",
  "predicates 3.0.3",
  "predicates-tree",
 ]
@@ -9818,9 +10124,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
  "cfg-if",
  "proc-macro2 1.0.86",
@@ -10034,7 +10340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
  "clap 3.2.25",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -10213,7 +10519,7 @@ dependencies = [
  "node-primitives",
  "node-testing",
  "parity-db",
- "rand",
+ "rand 0.8.5",
  "sc-basic-authorship",
  "sc-client-api",
  "sc-transaction-pool",
@@ -10421,6 +10727,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10560,7 +10883,16 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.1",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.0",
 ]
 
 [[package]]
@@ -10661,7 +10993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b1d40dd8f367db3c65bec8d3dd47d4a604ee8874480738f93191bddab4e0e0"
 dependencies = [
  "expander",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "itertools 0.11.0",
  "petgraph",
  "proc-macro-crate 3.1.0",
@@ -10970,8 +11302,8 @@ version = "4.0.0"
 dependencies = [
  "frame-election-provider-support",
  "honggfuzz",
- "pallet-bags-list",
- "rand",
+ "pallet-bags-list 27.0.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -11093,7 +11425,7 @@ dependencies = [
  "pallet-beefy-mmr",
  "pallet-mmr",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-consensus-beefy",
@@ -11250,14 +11582,34 @@ dependencies = [
  "pallet-session",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
- "sp-consensus-aura",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-staking",
- "sp-tracing 17.0.1",
+ "sp-consensus-aura 0.32.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "pallet-collator-selection"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658798d70c9054165169f6a6a96cfa9d6a5e7d24a524bc19825bf17fcbc5cc5a"
+dependencies = [
+ "frame-benchmarking 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "log",
+ "pallet-authorship 38.0.0",
+ "pallet-balances 39.0.0",
+ "pallet-session 38.0.0",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-runtime 39.0.2",
+ "sp-staking 36.0.0",
 ]
 
 [[package]]
@@ -11317,7 +11669,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "scale-info",
  "serde",
@@ -11334,6 +11686,39 @@ dependencies = [
  "wasm-instrument",
  "wasmi 0.32.3",
  "wat",
+]
+
+[[package]]
+name = "pallet-contracts"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df77077745d891c822b4275f273f336077a97e69e62a30134776aa721c96fee"
+dependencies = [
+ "bitflags 1.3.2",
+ "environmental",
+ "frame-benchmarking 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-balances 39.0.0",
+ "pallet-contracts-proc-macro 23.0.1",
+ "pallet-contracts-uapi 12.0.0",
+ "parity-scale-codec",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "smallvec",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staging-xcm 14.2.0",
+ "staging-xcm-builder 17.0.1",
+ "wasm-instrument",
+ "wasmi 0.32.3",
 ]
 
 [[package]]
@@ -11528,11 +11913,33 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "scale-info",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-npos-elections",
- "sp-runtime 40.1.0",
- "sp-staking",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-npos-elections 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-tracing 16.0.0",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-block"
+version = "0.9.0"
+dependencies = [
+ "frame-benchmarking 28.0.0",
+ "frame-election-provider-support 28.0.0",
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "log",
+ "pallet-balances 28.0.0",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-npos-elections 26.0.0",
+ "sp-runtime 31.0.1",
  "sp-std 14.0.0",
  "sp-tracing 17.0.1",
 ]
@@ -11550,7 +11957,31 @@ dependencies = [
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-npos-elections 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
+ "strum 0.26.3",
+]
+
+[[package]]
+name = "pallet-election-provider-multi-phase"
+version = "37.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f9ad5ae0c13ba3727183dadf1825b6b7b0b0598ed5c366f8697e13fd540f7d"
+dependencies = [
+ "frame-benchmarking 38.0.0",
+ "frame-election-provider-support 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "log",
+ "pallet-election-provider-support-benchmarking 37.0.0",
+ "parity-scale-codec",
+ "rand 0.8.5",
  "scale-info",
  "sp-arithmetic 26.0.0",
  "sp-core 35.0.0",
@@ -11925,7 +12356,7 @@ dependencies = [
  "frame-system",
  "log",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "scale-info",
  "serde",
@@ -12144,11 +12575,11 @@ dependencies = [
  "frame-system",
  "honggfuzz",
  "log",
- "pallet-nomination-pools",
- "rand",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1",
+ "pallet-nomination-pools 25.0.0",
+ "rand 0.8.5",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
 ]
 
 [[package]]
@@ -12646,6 +13077,206 @@ dependencies = [
  "sp-io 39.0.0",
  "sp-runtime 40.1.0",
  "sp-weights 31.0.0",
+]
+
+[[package]]
+name = "pallet-scored-pool"
+version = "28.0.0"
+dependencies = [
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "pallet-balances 28.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "pallet-scored-pool"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f84b48bb4702712c902f43931c4077d3a1cb6773c8d8c290d4a6251f6bc2a5c"
+dependencies = [
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+]
+
+[[package]]
+name = "pallet-session"
+version = "28.0.0"
+dependencies = [
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-timestamp 27.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-staking 26.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-trie 29.0.0",
+]
+
+[[package]]
+name = "pallet-session"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8474b62b6b7622f891e83d922a589e2ad5be5471f5ca47d45831a797dba0b3f4"
+dependencies = [
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-timestamp 37.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core 34.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+ "sp-session 36.0.0",
+ "sp-staking 36.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
+]
+
+[[package]]
+name = "pallet-session-benchmarking"
+version = "28.0.0"
+dependencies = [
+ "frame-benchmarking 28.0.0",
+ "frame-election-provider-support 28.0.0",
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "pallet-balances 28.0.0",
+ "pallet-session 28.0.0",
+ "pallet-staking 28.0.0",
+ "pallet-staking-reward-curve",
+ "pallet-timestamp 27.0.0",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+]
+
+[[package]]
+name = "pallet-session-benchmarking"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aadce7df0fee981721983795919642648b846dab5ab9096f82c2cea781007d0"
+dependencies = [
+ "frame-benchmarking 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "pallet-session 38.0.0",
+ "pallet-staking 38.0.0",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "sp-runtime 39.0.2",
+ "sp-session 36.0.0",
+]
+
+[[package]]
+name = "pallet-skip-feeless-payment"
+version = "3.0.0"
+dependencies = [
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "pallet-skip-feeless-payment"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8c2cb0dae13d2c2d2e76373f337d408468f571459df1900cbd7458f21cf6c01"
+dependencies = [
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 39.0.2",
+]
+
+[[package]]
+name = "pallet-society"
+version = "28.0.0"
+dependencies = [
+ "frame-benchmarking 28.0.0",
+ "frame-support 28.0.0",
+ "frame-support-test",
+ "frame-system 28.0.0",
+ "log",
+ "pallet-balances 28.0.0",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "sp-arithmetic 23.0.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+]
+
+[[package]]
+name = "pallet-society"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1dc69fea8a8de343e71691f009d5fece6ae302ed82b7bb357882b2ea6454143"
+dependencies = [
+ "frame-benchmarking 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "log",
+ "parity-scale-codec",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "sp-arithmetic 26.0.0",
+ "sp-io 38.0.0",
+ "sp-runtime 39.0.2",
+]
+
+[[package]]
+name = "pallet-staking"
+version = "28.0.0"
+dependencies = [
+ "frame-benchmarking 28.0.0",
+ "frame-election-provider-support 28.0.0",
+ "frame-support 28.0.0",
+ "frame-system 28.0.0",
+ "log",
+ "pallet-authorship 28.0.0",
+ "pallet-bags-list 27.0.0",
+ "pallet-balances 28.0.0",
+ "pallet-session 28.0.0",
+ "pallet-staking-reward-curve",
+ "pallet-timestamp 27.0.0",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-npos-elections 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-staking 26.0.0",
+ "sp-tracing 16.0.0",
  "substrate-test-utils",
 ]
 
@@ -13300,7 +13931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
+ "rand 0.8.5",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -13327,7 +13958,7 @@ dependencies = [
  "lz4",
  "memmap2 0.5.10",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "siphasher 0.3.11",
  "snap",
 ]
@@ -13813,7 +14444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
 ]
 
 [[package]]
@@ -13937,8 +14568,8 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnorrkel 0.11.4",
@@ -13963,15 +14594,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "rand",
- "rand_chacha",
- "sp-application-crypto 39.0.0",
- "sp-authority-discovery",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-tracing 17.0.1",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sp-application-crypto 30.0.0",
+ "sp-authority-discovery 26.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-tracing 16.0.0",
  "tracing-gum",
 ]
 
@@ -13994,14 +14625,14 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "polkadot-subsystem-bench",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "sc-network",
  "schnellru",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-tracing 17.0.1",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14026,14 +14657,14 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "polkadot-subsystem-bench",
- "rand",
+ "rand 0.8.5",
  "rstest",
  "sc-network",
  "schnellru",
- "sp-application-crypto 39.0.0",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-tracing 17.0.1",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tokio",
  "tracing-gum",
@@ -14099,11 +14730,11 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "schnellru",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tokio-util",
  "tracing-gum",
@@ -14130,7 +14761,7 @@ dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -14143,10 +14774,10 @@ dependencies = [
  "sc-keystore",
  "sc-network",
  "schnellru",
- "sp-application-crypto 39.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-tracing 17.0.1",
+ "sp-application-crypto 30.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14161,8 +14792,8 @@ dependencies = [
  "polkadot-primitives",
  "quickcheck",
  "reed-solomon-novelpoly",
- "sp-core 35.0.0",
- "sp-trie 38.0.0",
+ "sp-core 28.0.0",
+ "sp-trie 29.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -14181,8 +14812,8 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "quickcheck",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
  "sp-application-crypto 39.0.0",
@@ -14219,8 +14850,8 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "sc-network",
  "sp-consensus",
- "sp-core 35.0.0",
- "sp-keyring",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14273,21 +14904,21 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "polkadot-subsystem-bench",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnellru",
  "schnorrkel 0.11.4",
  "sp-application-crypto 39.0.0",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-slots",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14316,20 +14947,20 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "polkadot-subsystem-bench",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
  "schnorrkel 0.11.4",
  "sp-application-crypto 39.0.0",
  "sp-consensus",
- "sp-consensus-babe",
- "sp-consensus-slots",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1",
+ "sp-consensus-babe 0.32.0",
+ "sp-consensus-slots 0.32.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14356,9 +14987,9 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "sp-consensus",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-tracing 17.0.1",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14383,11 +15014,11 @@ dependencies = [
  "rstest",
  "sc-keystore",
  "schnellru",
- "sp-application-crypto 39.0.0",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-tracing 17.0.1",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14402,7 +15033,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "sp-keystore 0.41.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.65",
  "tracing-gum",
  "wasm-timer",
@@ -14471,8 +15102,8 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "sp-core 35.0.0",
+ "polkadot-primitives 7.0.0",
+ "sp-core 28.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14496,11 +15127,11 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "sc-keystore",
  "schnellru",
- "sp-application-crypto 39.0.0",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-tracing 17.0.1",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14516,7 +15147,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "sp-blockchain",
- "sp-inherents",
+ "sp-inherents 26.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14533,10 +15164,10 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "rand",
+ "rand 0.8.5",
  "rstest",
- "sp-core 35.0.0",
- "sp-tracing 17.0.1",
+ "sp-core 28.0.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14557,8 +15188,8 @@ dependencies = [
  "polkadot-primitives-test-helpers",
  "rstest",
  "schnellru",
- "sp-application-crypto 39.0.0",
- "sp-keystore 0.41.0",
+ "sp-application-crypto 30.0.0",
+ "sp-keystore 0.34.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14592,7 +15223,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "procfs",
- "rand",
+ "rand 0.8.5",
  "rococo-runtime",
  "rusty-fork",
  "sc-sysinfo",
@@ -14622,11 +15253,11 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "sc-keystore",
- "sp-application-crypto 39.0.0",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-runtime 40.1.0",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -14761,9 +15392,9 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives",
- "rand",
- "rand_chacha",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "sc-authority-discovery",
  "sc-network",
  "sc-network-types",
@@ -14794,7 +15425,7 @@ dependencies = [
  "sp-core 35.0.0",
  "sp-keystore 0.41.0",
  "sp-maybe-compressed-blob 11.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
  "zstd 0.12.4",
 ]
@@ -14886,7 +15517,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "prioritized-metered-channel",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "schnellru",
  "sp-application-crypto 39.0.0",
@@ -15085,15 +15716,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-primitives"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57bc055fa389372ec5fc0001b99aeffd50f3fd379280ce572d935189bb58dd8"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 34.0.0",
+ "sp-consensus-slots 0.40.1",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-staking 34.0.0",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb20b75d33212150242d39890d7ededab55f1084160c337f15d0eb8ca8c3ad4"
+dependencies = [
+ "bitvec",
+ "hex-literal",
+ "log",
+ "parity-scale-codec",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-authority-discovery 34.0.0",
+ "sp-consensus-slots 0.40.1",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-staking 36.0.0",
+]
+
+[[package]]
 name = "polkadot-primitives-test-helpers"
 version = "0.1.0"
 dependencies = [
- "polkadot-primitives",
- "rand",
- "sp-application-crypto 39.0.0",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-runtime 40.1.0",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
+ "sp-application-crypto 30.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -15228,9 +15913,9 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
- "polkadot-runtime-metrics",
- "rand",
- "rand_chacha",
+ "polkadot-runtime-metrics 7.0.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rstest",
  "sc-keystore",
  "scale-info",
@@ -15254,6 +15939,55 @@ dependencies = [
  "staging-xcm-executor",
  "static_assertions",
  "thousands",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "17.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd58e3a17e5df678f5737b018cbfec603af2c93bec56bbb9f8fb8b2b017b54b1"
+dependencies = [
+ "bitflags 1.3.2",
+ "bitvec",
+ "derive_more 0.99.17",
+ "frame-benchmarking 38.0.0",
+ "frame-support 38.0.0",
+ "frame-system 38.0.0",
+ "impl-trait-for-tuples",
+ "log",
+ "pallet-authority-discovery 38.0.0",
+ "pallet-authorship 38.0.0",
+ "pallet-babe 38.0.0",
+ "pallet-balances 39.0.0",
+ "pallet-broker 0.17.0",
+ "pallet-message-queue 41.0.1",
+ "pallet-mmr 38.0.0",
+ "pallet-session 38.0.0",
+ "pallet-staking 38.0.0",
+ "pallet-timestamp 37.0.0",
+ "pallet-vesting 38.0.0",
+ "parity-scale-codec",
+ "polkadot-core-primitives 15.0.0",
+ "polkadot-parachain-primitives 14.0.0",
+ "polkadot-primitives 16.0.0",
+ "polkadot-runtime-metrics 17.0.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-arithmetic 26.0.0",
+ "sp-core 34.0.0",
+ "sp-inherents 34.0.0",
+ "sp-io 38.0.0",
+ "sp-keystore 0.40.0",
+ "sp-runtime 39.0.2",
+ "sp-session 36.0.0",
+ "sp-staking 36.0.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "staging-xcm 14.2.0",
+ "staging-xcm-executor 17.0.0",
 ]
 
 [[package]]
@@ -15693,8 +16427,8 @@ dependencies = [
  "polkadot-sdk",
  "polkadot-sdk-docs-first-pallet",
  "polkadot-sdk-docs-first-runtime",
- "polkadot-sdk-frame",
- "rand",
+ "polkadot-sdk-frame 0.1.0",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-cli",
  "sc-client-db",
@@ -15928,7 +16662,7 @@ dependencies = [
  "fatality",
  "futures",
  "futures-timer",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -15938,17 +16672,17 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-primitives-test-helpers",
  "polkadot-subsystem-bench",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rstest",
  "sc-keystore",
  "sc-network",
- "sp-application-crypto 39.0.0",
- "sp-authority-discovery",
- "sp-core 35.0.0",
- "sp-keyring",
- "sp-keystore 0.41.0",
- "sp-staking",
- "sp-tracing 17.0.1",
+ "sp-application-crypto 30.0.0",
+ "sp-authority-discovery 26.0.0",
+ "sp-core 28.0.0",
+ "sp-keyring 31.0.0",
+ "sp-keystore 0.34.0",
+ "sp-staking 26.0.0",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing-gum",
 ]
@@ -16009,8 +16743,8 @@ dependencies = [
  "prometheus",
  "pyroscope",
  "pyroscope_pprofrs",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rand_distr",
  "sc-keystore",
@@ -16091,10 +16825,10 @@ dependencies = [
  "polkadot-node-subsystem-test-helpers",
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
- "rand",
- "sp-core 35.0.0",
- "sp-keystore 0.41.0",
+ "polkadot-primitives 7.0.0",
+ "rand 0.8.5",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
  "substrate-build-script-utils",
  "tracing-gum",
 ]
@@ -16179,7 +16913,7 @@ dependencies = [
  "polkadot-runtime-parachains",
  "polkadot-service",
  "polkadot-test-runtime",
- "rand",
+ "rand 0.8.5",
  "sc-authority-discovery",
  "sc-chain-spec",
  "sc-cli",
@@ -16514,7 +17248,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be97d76faf1bfab666e1375477b23fde79eccf0276e9b63b92a39d676a889ba9"
 dependencies = [
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -16855,8 +17589,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.2",
  "rusty-fork",
@@ -16984,7 +17718,7 @@ dependencies = [
  "log",
  "names",
  "prost 0.11.9",
- "reqwest 0.11.20",
+ "reqwest 0.11.27",
  "thiserror 1.0.65",
  "url",
  "winapi",
@@ -17013,7 +17747,7 @@ dependencies = [
  "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -17050,7 +17784,7 @@ dependencies = [
  "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf 0.8.1",
- "thiserror 2.0.12",
+ "thiserror 1.0.65",
  "unsigned-varint 0.8.0",
 ]
 
@@ -17073,7 +17807,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger 0.8.4",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -17088,8 +17822,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
- "socket2 0.5.7",
+ "rustls 0.23.18",
+ "socket2 0.5.8",
  "thiserror 1.0.65",
  "tokio",
  "tracing",
@@ -17102,7 +17836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
  "rustls 0.23.14",
@@ -17120,7 +17854,7 @@ checksum = "8bffec3605b73c6f1754535084a85229fa8a30f86014e6c81aeec4abb68b0285"
 dependencies = [
  "libc",
  "once_cell",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -17156,8 +17890,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -17168,6 +17913,16 @@ checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.1",
 ]
 
 [[package]]
@@ -17182,7 +17937,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88e0da7a2c97baa202165137c158d0a2e824ac465d13d81046727b34cb247d3"
+dependencies = [
+ "getrandom 0.3.1",
+ "zerocopy 0.8.20",
 ]
 
 [[package]]
@@ -17192,7 +17957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -17341,7 +18106,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
  "redox_syscall 0.2.16",
  "thiserror 1.0.65",
 ]
@@ -17480,7 +18245,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "quick_cache",
- "rand",
+ "rand 0.8.5",
  "relay-utils",
  "sc-chain-spec",
  "sc-rpc-api",
@@ -17492,9 +18257,9 @@ dependencies = [
  "sp-rpc",
  "sp-runtime 40.1.0",
  "sp-std 14.0.0",
- "sp-trie 38.0.0",
- "sp-version 38.0.0",
- "staging-xcm",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "staging-xcm 7.0.0",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -17668,7 +18433,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.10",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -18024,7 +18789,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp 0.5.2",
  "ruint-macro",
  "serde",
@@ -18398,13 +19163,23 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
+version = "23.0.0"
+dependencies = [
+ "log",
+ "sp-core 28.0.0",
+ "sp-wasm-interface 20.0.0",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sc-allocator"
 version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3f01218e73ea57916be5f08987995ac802d6f4ede4ea5ce0242e468c590e4e2"
 dependencies = [
  "log",
  "sp-core 33.0.1",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface 21.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -18434,7 +19209,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-build",
  "quickcheck",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-network",
  "sc-network-types",
@@ -18549,7 +19324,7 @@ dependencies = [
  "names",
  "parity-bip39",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -18622,8 +19397,7 @@ dependencies = [
  "parity-db",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "quickcheck",
- "rand",
+ "rand 0.8.5",
  "sc-client-api",
  "sc-state-db",
  "schnellru",
@@ -18865,7 +19639,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -19056,19 +19830,9 @@ dependencies = [
  "sp-externalities 0.30.0",
  "sp-io 39.0.0",
  "sp-maybe-compressed-blob 11.0.0",
- "sp-panic-handler 13.0.1",
- "sp-runtime 40.1.0",
- "sp-runtime-interface 29.0.0",
- "sp-state-machine 0.44.0",
- "sp-tracing 17.0.1",
- "sp-trie 38.0.0",
- "sp-version 38.0.0",
- "sp-wasm-interface 21.0.1",
- "substrate-test-runtime",
- "tempfile",
- "tracing",
- "tracing-subscriber 0.3.18",
- "wat",
+ "sp-wasm-interface 20.0.0",
+ "thiserror 1.0.65",
+ "wasm-instrument",
 ]
 
 [[package]]
@@ -19080,7 +19844,7 @@ dependencies = [
  "polkavm 0.9.3",
  "sc-allocator 28.0.0",
  "sp-maybe-compressed-blob 11.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface 21.0.1",
  "thiserror 1.0.65",
  "wasm-instrument",
 ]
@@ -19213,10 +19977,10 @@ dependencies = [
  "sc-transaction-pool-api",
  "sp-api 35.0.0",
  "sp-consensus",
- "sp-core 35.0.0",
- "sp-keystore 0.41.0",
- "sp-mixnet",
- "sp-runtime 40.1.0",
+ "sp-core 28.0.0",
+ "sp-keystore 0.34.0",
+ "sp-mixnet 0.4.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -19250,7 +20014,7 @@ dependencies = [
  "pin-project",
  "prost 0.12.6",
  "prost-build",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -19342,8 +20106,8 @@ dependencies = [
  "sc-network",
  "sc-network-types",
  "sp-blockchain",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -19416,7 +20180,7 @@ dependencies = [
  "libp2p 0.54.2",
  "log",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-client-api",
  "sc-consensus",
@@ -19467,7 +20231,7 @@ dependencies = [
  "multiaddr 0.18.1",
  "multihash 0.19.1",
  "quickcheck",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.65",
  "zeroize",
 ]
@@ -19491,8 +20255,8 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
- "rustls 0.23.14",
+ "rand 0.8.5",
+ "rustls 0.23.18",
  "sc-block-builder",
  "sc-client-api",
  "sc-client-db",
@@ -19578,8 +20342,8 @@ dependencies = [
  "serde_json",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
- "sp-version 38.0.0",
+ "sp-runtime 31.0.1",
+ "sp-version 29.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -19621,7 +20385,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -19654,11 +20418,30 @@ dependencies = [
 name = "sc-runtime-test"
 version = "2.0.0"
 dependencies = [
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-runtime-interface 29.0.0",
- "substrate-wasm-builder",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
+ "substrate-wasm-builder 17.0.0",
+]
+
+[[package]]
+name = "sc-runtime-utilities"
+version = "0.1.0"
+dependencies = [
+ "cumulus-primitives-proof-size-hostfunction 0.2.0",
+ "cumulus-test-runtime",
+ "parity-scale-codec",
+ "sc-executor 0.32.0",
+ "sc-executor-common 0.29.0",
+ "sp-core 28.0.0",
+ "sp-crypto-hashing 0.1.0",
+ "sp-io 30.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-version 29.0.0",
+ "sp-wasm-interface 20.0.0",
+ "subxt",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -19675,7 +20458,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -19799,7 +20582,7 @@ dependencies = [
  "clap 4.5.13",
  "fs4",
  "log",
- "sp-core 35.0.0",
+ "sp-core 28.0.0",
  "thiserror 1.0.65",
  "tokio",
 ]
@@ -19818,7 +20601,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-runtime 40.1.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -19830,7 +20613,7 @@ dependencies = [
  "futures",
  "libc",
  "log",
- "rand",
+ "rand 0.8.5",
  "rand_pcg",
  "regex",
  "sc-telemetry",
@@ -19853,8 +20636,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "sc-network",
+ "rand 0.8.5",
  "sc-utils",
  "serde",
  "serde_json",
@@ -19883,8 +20665,8 @@ dependencies = [
  "sp-blockchain",
  "sp-core 35.0.0",
  "sp-rpc",
- "sp-runtime 40.1.0",
- "sp-tracing 17.0.1",
+ "sp-runtime 31.0.1",
+ "sp-tracing 16.0.0",
  "thiserror 1.0.65",
  "tracing",
  "tracing-log 0.2.0",
@@ -19911,7 +20693,7 @@ dependencies = [
  "criterion",
  "futures",
  "futures-timer",
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "itertools 0.11.0",
  "linked-hash-map",
  "log",
@@ -19945,13 +20727,14 @@ version = "38.0.0"
 dependencies = [
  "async-trait",
  "futures",
+ "indexmap 2.7.1",
  "log",
  "parity-scale-codec",
  "serde",
  "serde_json",
  "sp-blockchain",
- "sp-core 35.0.0",
- "sp-runtime 40.1.0",
+ "sp-core 28.0.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -20081,7 +20864,7 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "scale-info",
- "syn 2.0.87",
+ "syn 2.0.98",
  "thiserror 1.0.65",
 ]
 
@@ -20243,7 +21026,18 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.9.2",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand 0.8.5",
+ "secp256k1-sys 0.10.1",
 ]
 
 [[package]]
@@ -20426,7 +21220,7 @@ version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "itoa",
  "memchr",
  "ryu",
@@ -20460,7 +21254,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "itoa",
  "ryu",
  "serde",
@@ -20606,9 +21400,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.7.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c80e565e7dcc4f1ef247e2f395550d4cf7d777746d5988e7e4e3156b71077fc"
+checksum = "dee851d0e5e7af3721faea1843e8015e820a234f81fda3dea9247e15bac9a86a"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -20766,8 +21560,8 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "ruzstd 0.4.0",
  "schnorrkel 0.10.2",
  "serde",
@@ -20821,9 +21615,9 @@ dependencies = [
  "pbkdf2",
  "pin-project",
  "poly1305",
- "rand",
- "rand_chacha",
- "ruzstd 0.5.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "ruzstd 0.6.0",
  "schnorrkel 0.11.4",
  "serde",
  "serde_json",
@@ -20864,8 +21658,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 0.3.11",
@@ -20900,8 +21694,8 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "serde",
  "serde_json",
  "siphasher 1.0.1",
@@ -21000,7 +21794,7 @@ dependencies = [
  "hex-literal",
  "parity-bytes",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "rlp 0.6.1",
  "scale-info",
  "serde",
@@ -21021,7 +21815,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "snowbridge-amcl",
  "zeroize",
@@ -21065,7 +21859,7 @@ dependencies = [
  "log",
  "pallet-timestamp",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "serde_json",
@@ -21267,9 +22061,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -21286,7 +22080,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha-1",
 ]
 
@@ -21302,7 +22096,7 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
@@ -21372,21 +22166,43 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde_json",
- "sp-api 35.0.0",
- "sp-block-builder",
- "sp-consensus-aura",
- "sp-consensus-grandpa",
- "sp-core 35.0.0",
- "sp-genesis-builder",
- "sp-inherents",
- "sp-keyring",
- "sp-offchain",
- "sp-runtime 40.1.0",
- "sp-session",
- "sp-storage 22.0.0",
- "sp-transaction-pool",
- "sp-version 38.0.0",
- "substrate-wasm-builder",
+ "sp-api 26.0.0",
+ "sp-block-builder 26.0.0",
+ "sp-consensus-aura 0.32.0",
+ "sp-consensus-grandpa 13.0.0",
+ "sp-core 28.0.0",
+ "sp-genesis-builder 0.8.0",
+ "sp-inherents 26.0.0",
+ "sp-keyring 31.0.0",
+ "sp-offchain 26.0.0",
+ "sp-runtime 31.0.1",
+ "sp-session 27.0.0",
+ "sp-storage 19.0.0",
+ "sp-transaction-pool 26.0.0",
+ "sp-version 29.0.0",
+ "substrate-wasm-builder 17.0.0",
+]
+
+[[package]]
+name = "sp-api"
+version = "26.0.0"
+dependencies = [
+ "docify",
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 15.0.0",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-metadata-ir 0.6.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
+ "sp-state-machine 0.35.0",
+ "sp-test-primitives",
+ "sp-trie 29.0.0",
+ "sp-version 29.0.0",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -21421,17 +22237,30 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-api-proc-macro 21.0.0",
- "sp-core 35.0.0",
- "sp-externalities 0.30.0",
- "sp-metadata-ir 0.8.0",
- "sp-runtime 40.1.0",
- "sp-runtime-interface 29.0.0",
- "sp-state-machine 0.44.0",
- "sp-test-primitives",
- "sp-trie 38.0.0",
- "sp-version 38.0.0",
+ "sp-api-proc-macro 20.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-metadata-ir 0.7.0",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
+ "sp-state-machine 0.43.0",
+ "sp-trie 37.0.0",
+ "sp-version 37.0.0",
  "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sp-api-proc-macro"
+version = "15.0.0"
+dependencies = [
+ "Inflector",
+ "assert_matches",
+ "blake2 0.10.6",
+ "expander",
+ "proc-macro-crate 3.1.0",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -21575,7 +22404,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "primitive-types 0.13.1",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-crypto-hashing 0.1.0",
@@ -21641,8 +22470,8 @@ dependencies = [
  "sp-consensus",
  "sp-core 35.0.0",
  "sp-database",
- "sp-runtime 40.1.0",
- "sp-state-machine 0.44.0",
+ "sp-runtime 31.0.1",
+ "sp-state-machine 0.35.0",
  "thiserror 1.0.65",
  "tracing",
 ]
@@ -21777,8 +22606,9 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
- "primitive-types 0.12.2",
- "rand",
+ "primitive-types 0.13.1",
+ "rand 0.8.5",
+ "regex",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -21791,7 +22621,7 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 20.0.0",
  "ss58-registry",
- "substrate-bip39 0.5.0",
+ "substrate-bip39 0.4.7",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -21825,7 +22655,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.12.2",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -21838,7 +22668,7 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-bip39 0.6.0",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -21872,7 +22702,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.12.2",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -21885,7 +22715,54 @@ dependencies = [
  "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-bip39 0.6.0",
+ "thiserror 1.0.65",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c961a5e33fb2962fa775c044ceba43df9c6f917e2c35d63bfe23738468fa76a7"
+dependencies = [
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2 0.10.6",
+ "bounded-collections",
+ "bs58",
+ "dyn-clonable",
+ "ed25519-zebra 4.0.3",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde 0.4.0",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "paste",
+ "primitive-types 0.12.2",
+ "rand 0.8.5",
+ "scale-info",
+ "schnorrkel 0.11.4",
+ "secp256k1 0.28.2",
+ "secrecy 0.8.0",
+ "serde",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.29.0",
+ "sp-runtime-interface 28.0.0",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-storage 21.0.0",
+ "ss58-registry",
+ "substrate-bip39 0.6.0",
  "thiserror 1.0.65",
  "tracing",
  "w3f-bls",
@@ -21918,8 +22795,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "primitive-types 0.13.1",
- "rand",
- "regex",
+ "rand 0.8.5",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
@@ -22110,7 +22986,21 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 40.1.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sp-inherents"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afffbddc380d99a90c459ba1554bbbc01d62e892de9f1485af6940b89c4c0d57"
+dependencies = [
+ "async-trait",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime 39.0.2",
  "thiserror 1.0.65",
 ]
 
@@ -22237,8 +23127,10 @@ checksum = "bdbab8b61bd61d5f8625a0c75753b5d5a23be55d3445419acd42caf59cf6236b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
 ]
 
 [[package]]
@@ -22338,7 +23230,25 @@ dependencies = [
  "sp-api 35.0.0",
  "sp-core 35.0.0",
  "sp-debug-derive 14.0.0",
- "sp-runtime 40.1.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sp-mmr-primitives"
+version = "34.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a12dd76e368f1e48144a84b4735218b712f84b3f976970e2f25a29b30440e10"
+dependencies = [
+ "log",
+ "parity-scale-codec",
+ "polkadot-ckb-merkle-mountain-range 0.7.0",
+ "scale-info",
+ "serde",
+ "sp-api 34.0.0",
+ "sp-core 34.0.0",
+ "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 39.0.2",
  "thiserror 1.0.65",
 ]
 
@@ -22347,7 +23257,7 @@ name = "sp-npos-elections"
 version = "35.0.0"
 dependencies = [
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "sp-arithmetic 26.0.0",
@@ -22362,9 +23272,9 @@ version = "2.0.0"
 dependencies = [
  "clap 4.5.13",
  "honggfuzz",
- "rand",
- "sp-npos-elections",
- "sp-runtime 40.1.0",
+ "rand 0.8.5",
+ "sp-npos-elections 26.0.0",
+ "sp-runtime 31.0.1",
 ]
 
 [[package]]
@@ -22418,7 +23328,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid 0.1.1",
@@ -22443,7 +23353,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid 0.1.1",
@@ -22469,7 +23379,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "simple-mermaid 0.1.1",
@@ -22494,7 +23404,7 @@ dependencies = [
  "num-traits",
  "parity-scale-codec",
  "paste",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "serde",
  "serde_json",
@@ -22677,13 +23587,14 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "pretty_assertions",
+ "rand 0.8.5",
  "smallvec",
  "sp-core 31.0.0",
  "sp-externalities 0.27.0",
  "sp-panic-handler 13.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-trie 32.0.0",
+ "sp-runtime 31.0.1",
+ "sp-trie 29.0.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.28.0",
@@ -22699,7 +23610,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core 32.0.0",
  "sp-externalities 0.28.0",
@@ -22720,7 +23631,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "sp-core 33.0.1",
  "sp-externalities 0.28.0",
@@ -22742,14 +23653,12 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "smallvec",
- "sp-core 35.0.0",
- "sp-externalities 0.30.0",
- "sp-panic-handler 13.0.1",
- "sp-runtime 40.1.0",
- "sp-trie 38.0.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
+ "sp-panic-handler 13.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie 37.0.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.29.1",
@@ -22764,19 +23673,49 @@ dependencies = [
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "sha2 0.10.8",
  "sp-api 35.0.0",
  "sp-application-crypto 39.0.0",
  "sp-core 35.0.0",
  "sp-crypto-hashing 0.1.0",
- "sp-externalities 0.30.0",
- "sp-runtime 40.1.0",
- "sp-runtime-interface 29.0.0",
+ "sp-externalities 0.25.0",
+ "sp-runtime 31.0.1",
+ "sp-runtime-interface 24.0.0",
  "thiserror 1.0.65",
  "x25519-dalek",
 ]
+
+[[package]]
+name = "sp-statement-store"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c219bc34ef4d1f9835f3ed881f965643c32034fcc030eb33b759dadbc802c1c2"
+dependencies = [
+ "aes-gcm",
+ "curve25519-dalek 4.1.3",
+ "ed25519-dalek",
+ "hkdf",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "scale-info",
+ "sha2 0.10.8",
+ "sp-api 34.0.0",
+ "sp-application-crypto 38.0.0",
+ "sp-core 34.0.0",
+ "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-externalities 0.29.0",
+ "sp-runtime 39.0.2",
+ "sp-runtime-interface 28.0.0",
+ "thiserror 1.0.65",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "sp-std"
+version = "8.0.0"
+source = "git+https://github.com/paritytech/polkadot-sdk#82912acb33a9030c0ef3bf590a34fca09b72dc5f"
 
 [[package]]
 name = "sp-std"
@@ -22844,8 +23783,21 @@ version = "35.0.0"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
- "sp-inherents",
- "sp-runtime 40.1.0",
+ "sp-inherents 26.0.0",
+ "sp-runtime 31.0.1",
+ "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sp-timestamp"
+version = "34.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a1cb4df653d62ccc0dbce1db45d1c9443ec60247ee9576962d24da4c9c6f07"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "sp-inherents 34.0.0",
+ "sp-runtime 39.0.2",
  "thiserror 1.0.65",
 ]
 
@@ -22918,12 +23870,12 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 31.0.0",
- "sp-externalities 0.27.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-core 28.0.0",
+ "sp-externalities 0.25.0",
+ "sp-runtime 31.0.1",
  "thiserror 1.0.65",
  "tracing",
  "trie-db 0.28.0",
@@ -22943,7 +23895,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core 32.0.0",
@@ -22967,7 +23919,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
  "sp-core 33.0.1",
@@ -22990,18 +23942,32 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.3",
- "rand",
+ "rand 0.8.5",
  "scale-info",
  "schnellru",
- "sp-core 35.0.0",
- "sp-externalities 0.30.0",
- "sp-runtime 40.1.0",
+ "sp-core 34.0.0",
+ "sp-externalities 0.29.0",
  "thiserror 1.0.65",
  "tracing",
  "trie-bench",
  "trie-db 0.29.1",
  "trie-root",
- "trie-standardmap",
+]
+
+[[package]]
+name = "sp-version"
+version = "29.0.0"
+dependencies = [
+ "impl-serde 0.5.0",
+ "parity-scale-codec",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro 0.1.0",
+ "sp-runtime 31.0.1",
+ "sp-std 14.0.0",
+ "sp-version-proc-macro 13.0.0",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -23031,11 +23997,23 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0",
- "sp-runtime 40.1.0",
- "sp-std 14.0.0",
- "sp-version-proc-macro 15.0.0",
+ "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime 39.0.2",
+ "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-version-proc-macro 14.0.0",
  "thiserror 1.0.65",
+]
+
+[[package]]
+name = "sp-version-proc-macro"
+version = "13.0.0"
+dependencies = [
+ "parity-scale-codec",
+ "proc-macro-warning",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "sp-version 29.0.0",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -23179,6 +24157,210 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlformat"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
+dependencies = [
+ "nom",
+ "unicode_categories",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+dependencies = [
+ "atoi",
+ "byteorder",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener 5.3.1",
+ "futures-channel",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.14.5",
+ "hashlink 0.9.1",
+ "hex",
+ "indexmap 2.7.1",
+ "log",
+ "memchr",
+ "once_cell",
+ "paste",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "smallvec",
+ "sqlformat",
+ "thiserror 1.0.65",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.98",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array 0.14.7",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.8",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.65",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.6.0",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac 0.12.1",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 1.0.65",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "ss58-registry"
 version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23258,7 +24440,7 @@ dependencies = [
  "platforms",
  "polkadot-sdk",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sc-service-test",
  "scale-info",
@@ -23286,10 +24468,10 @@ dependencies = [
  "sc-client-api",
  "sc-service",
  "sp-blockchain",
- "sp-core 35.0.0",
- "sp-io 39.0.0",
- "sp-runtime 40.1.0",
- "sp-statement-store",
+ "sp-core 28.0.0",
+ "sp-io 30.0.0",
+ "sp-runtime 31.0.1",
+ "sp-statement-store 10.0.0",
  "thiserror 1.0.65",
 ]
 
@@ -23751,7 +24933,7 @@ dependencies = [
  "sp-core 32.0.0",
  "sp-io 35.0.0",
  "sp-runtime 36.0.0",
- "sp-wasm-interface 21.0.0",
+ "sp-wasm-interface 21.0.1",
  "thiserror 1.0.65",
 ]
 
@@ -23951,8 +25133,8 @@ dependencies = [
  "ipfs-hasher",
  "log",
  "num-format",
- "rand",
- "reqwest 0.12.5",
+ "rand 0.8.5",
+ "reqwest 0.12.9",
  "scale-info",
  "semver 1.0.18",
  "serde",
@@ -23997,6 +25179,7 @@ dependencies = [
  "subxt-macro",
  "subxt-metadata",
  "thiserror 1.0.65",
+ "tokio",
  "tokio-util",
  "tracing",
  "url",
@@ -24018,9 +25201,8 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.87",
+ "syn 2.0.98",
  "thiserror 1.0.65",
- "tokio",
 ]
 
 [[package]]
@@ -24062,7 +25244,7 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
- "smoldot-light 0.14.0",
+ "smoldot-light 0.16.2",
  "thiserror 1.0.65",
  "tokio",
  "tokio-stream",
@@ -24119,6 +25301,17 @@ dependencies = [
  "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subxt-core",
  "zeroize",
+]
+
+[[package]]
+name = "subxt-utils-fetchmetadata"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082b17a86e3c3fe45d858d94d68f6b5247caace193dad6201688f24db8ba9bb"
+dependencies = [
+ "hex",
+ "parity-scale-codec",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -24562,11 +25755,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -24609,6 +25802,17 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -24710,6 +25914,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -24747,7 +25961,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -24790,7 +26004,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "tokio",
 ]
 
@@ -24859,11 +26073,24 @@ checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.21.7",
- "rustls-native-certs 0.6.3",
  "tokio",
- "tokio-rustls 0.24.1",
  "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.18",
+ "rustls-native-certs 0.8.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tungstenite 0.26.2",
 ]
 
 [[package]]
@@ -24929,9 +26156,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
- "serde",
- "serde_spanned",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -24942,7 +26167,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "toml_datetime",
  "winnow 0.5.15",
 ]
@@ -24953,7 +26178,7 @@ version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.7.1",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -25266,8 +26491,7 @@ dependencies = [
  "http 0.2.9",
  "httparse",
  "log",
- "rand",
- "rustls 0.21.7",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.65",
  "url",
@@ -25286,12 +26510,32 @@ dependencies = [
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.65",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "rustls 0.23.18",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.11",
  "url",
  "utf-8",
 ]
@@ -25310,7 +26554,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -25483,12 +26727,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna 1.0.3",
  "percent-encoding",
  "serde",
 ]
@@ -25498,6 +26742,18 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -25511,7 +26767,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.10",
 ]
 
 [[package]]
@@ -25595,8 +26851,8 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3 0.10.8",
@@ -25643,6 +26899,21 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -26117,7 +27388,7 @@ dependencies = [
  "memfd",
  "memoffset 0.8.0",
  "paste",
- "rand",
+ "rand 0.8.5",
  "rustix 0.36.15",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -26703,14 +27974,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
+name = "wit-bindgen-rt"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "bitflags 2.6.0",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -26723,9 +28005,9 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb66477291e7e8d2b0ff1bcb900bf29489a9692816d79874bea351e7a8b6de96"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
@@ -26739,14 +28021,31 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.1",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.0",
  "rusticata-macros",
  "thiserror 1.0.65",
+ "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.0",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.11",
  "time",
 ]
 
@@ -26977,7 +28276,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
 ]
 
@@ -26992,7 +28291,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot 0.12.3",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "static_assertions",
  "web-time",
 ]
@@ -27019,12 +28318,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+ "synstructure 0.13.1",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.32",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde3bb8c68a8f3f1ed4ac9221aad6b10cece3e60a8e2ea54a6a2dec806d0084c"
+dependencies = [
+ "zerocopy-derive 0.8.20",
 ]
 
 [[package]]
@@ -27036,6 +28368,38 @@ dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.37",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eea57037071898bf96a6da35fd626f4f27e9cee3ead2a6c703cf09d472b2e700"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -27059,6 +28423,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2 1.0.93",
+ "quote 1.0.38",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "zombienet-backchannel"
 version = "1.0.0"
 dependencies = [
@@ -27069,7 +28455,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.65",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing-gum",
  "url",
 ]
@@ -27108,7 +28494,7 @@ dependencies = [
  "libp2p 0.52.4",
  "libsecp256k1",
  "multiaddr 0.18.1",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest 0.11.20",
  "serde",
@@ -27195,10 +28581,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "nix 0.27.1",
- "rand",
+ "nix 0.29.0",
+ "rand 0.8.5",
  "regex",
- "reqwest 0.11.20",
+ "reqwest 0.11.27",
  "thiserror 1.0.65",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -817,7 +817,7 @@ hyper-rustls = { version = "0.27.3", default-features = false, features = ["http
 hyper-util = { version = "0.1.5", default-features = false }
 impl-serde = { version = "0.5.0", default-features = false }
 impl-trait-for-tuples = { version = "0.2.2" }
-indexmap = { version = "2.0.0" }
+indexmap = { version = "2.7.1" }
 indicatif = { version = "0.17.7" }
 integer-sqrt = { version = "0.1.2" }
 ip_network = { version = "0.4.1" }
@@ -846,7 +846,7 @@ linked-hash-map = { version = "0.5.4" }
 linked_hash_set = { version = "0.1.4" }
 linregress = { version = "0.5.1" }
 lite-json = { version = "0.2.0", default-features = false }
-litep2p = { version = "0.9.0", features = ["websocket"] }
+litep2p = { version = "0.9.1", features = ["websocket"] }
 log = { version = "0.4.22", default-features = false }
 macro_magic = { version = "0.5.1" }
 maplit = { version = "1.0.2" }
@@ -1359,7 +1359,7 @@ tt-call = { version = "1.0.8" }
 tuplex = { version = "0.1", default-features = false }
 twox-hash = { version = "1.6.3", default-features = false }
 unsigned-varint = { version = "0.7.2" }
-url = { version = "2.4.0" }
+url = { version = "2.5.4" }
 void = { version = "1.0.2" }
 w3f-bls = { version = "0.1.3", default-features = false }
 wait-timeout = { version = "0.2" }

--- a/prdoc/pr_7338.prdoc
+++ b/prdoc/pr_7338.prdoc
@@ -1,0 +1,10 @@
+title: '[net/libp2p] Use raw `Identify` observed addresses to discover external addresses'
+doc:
+- audience: Node Dev
+  description: |-
+    Instead of using libp2p-provided external address candidates, susceptible to address translation issues, use litep2p-backend approach based on confirming addresses observed by multiple peers as external.
+
+    Fixes https://github.com/paritytech/polkadot-sdk/issues/7207.
+crates:
+- name: sc-network
+  bump: major

--- a/prdoc/pr_7640.prdoc
+++ b/prdoc/pr_7640.prdoc
@@ -1,0 +1,25 @@
+title: Bring the latest compatibility fixes via litep2p v0.9.1
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      This release enhances compatibility between litep2p and libp2p by using the latest Yamux upstream version.
+      Additionally, it includes various improvements and fixes to boost the stability and performance of the WebSocket stream and the multistream-select protocol.
+
+crates:
+  - name: sc-network
+    bump: minor
+  - name: cumulus-client-cli
+    bump: minor
+  - name: sc-network-types
+    bump: minor
+  - name: sc-transaction-pool-api
+    bump: minor
+  - name: sc-transaction-pool
+    bump: minor
+  - name: polkadot-statement-distribution
+    bump: minor
+  - name: polkadot-dispute-distribution
+    bump: minor
+  - name: cumulus-relay-chain-rpc-interface
+    bump: minor

--- a/prdoc/pr_7724.prdoc
+++ b/prdoc/pr_7724.prdoc
@@ -1,0 +1,13 @@
+title: Terminate libp2p the outbound notification substream on io errors
+
+doc:
+  - audience: [Node Dev, Node Operator]
+    description: |
+      This PR handles a case where we called the poll_next on an outbound substream notification to check if the stream is closed.
+      It is entirely possible that the poll_next would return an io::error, for example end of file.
+      This PR ensures that we make the distinction between unexpected incoming data, and error originated from poll_next.
+      While at it, the bulk of the PR change propagates the PeerID from the network behavior, through the notification handler, to the notification outbound stream for logging purposes.
+
+crates:
+  - name: sc-network
+    bump: patch

--- a/substrate/client/network/src/behaviour.rs
+++ b/substrate/client/network/src/behaviour.rs
@@ -184,6 +184,7 @@ impl<B: BlockT> Behaviour<B> {
 		request_response_protocols: Vec<ProtocolConfig>,
 		peer_store_handle: Arc<dyn PeerStoreProvider>,
 		external_addresses: Arc<Mutex<HashSet<Multiaddr>>>,
+		public_addresses: Vec<Multiaddr>,
 		connection_limits: ConnectionLimits,
 	) -> Result<Self, request_responses::RegisterError> {
 		Ok(Self {
@@ -192,6 +193,7 @@ impl<B: BlockT> Behaviour<B> {
 				user_agent,
 				local_public_key,
 				external_addresses,
+				public_addresses,
 			),
 			discovery: disco_config.finish(),
 			request_responses: request_responses::RequestResponsesBehaviour::new(

--- a/substrate/client/network/src/lib.rs
+++ b/substrate/client/network/src/lib.rs
@@ -291,6 +291,9 @@ pub use service::{
 };
 pub use types::ProtocolName;
 
+/// Log target for `sc-network`.
+const LOG_TARGET: &str = "sub-libp2p";
+
 /// The maximum allowed number of established connections per peer.
 ///
 /// Typically, and by design of the network behaviours in this crate,

--- a/substrate/client/network/src/litep2p/discovery.rs
+++ b/substrate/client/network/src/litep2p/discovery.rs
@@ -50,6 +50,7 @@ use schnellru::{ByLength, LruMap};
 use std::{
 	cmp,
 	collections::{HashMap, HashSet, VecDeque},
+	iter,
 	num::NonZeroUsize,
 	pin::Pin,
 	sync::Arc,
@@ -72,11 +73,9 @@ const GET_RECORD_REDUNDANCY_FACTOR: usize = 4;
 /// The maximum number of tracked external addresses we allow.
 const MAX_EXTERNAL_ADDRESSES: u32 = 32;
 
-/// Minimum number of confirmations received before an address is verified.
-///
-/// Note: all addresses are confirmed by libp2p on the first encounter. This aims to make
-/// addresses a bit more robust.
-const MIN_ADDRESS_CONFIRMATIONS: usize = 2;
+/// Number of times observed address is received from different peers before it is confirmed as
+/// external.
+const MIN_ADDRESS_CONFIRMATIONS: usize = 3;
 
 /// Discovery events.
 #[derive(Debug)]
@@ -486,7 +485,7 @@ impl Discovery {
 					.flatten()
 					.flatten();
 
-				self.address_confirmations.insert(address.clone(), Default::default());
+				self.address_confirmations.insert(address.clone(), iter::once(peer).collect());
 
 				return (false, oldest)
 			},

--- a/substrate/client/network/src/litep2p/mod.rs
+++ b/substrate/client/network/src/litep2p/mod.rs
@@ -39,7 +39,6 @@ use crate::{
 		},
 	},
 	peer_store::PeerStoreProvider,
-	protocol,
 	service::{
 		metrics::{register_without_sources, MetricSources, Metrics, NotificationMetrics},
 		out_events,
@@ -266,57 +265,6 @@ impl Litep2pNetworkBackend {
 		};
 		let config_builder = ConfigBuilder::new();
 
-		// The yamux buffer size limit is configured to be equal to the maximum frame size
-		// of all protocols. 10 bytes are added to each limit for the length prefix that
-		// is not included in the upper layer protocols limit but is still present in the
-		// yamux buffer. These 10 bytes correspond to the maximum size required to encode
-		// a variable-length-encoding 64bits number. In other words, we make the
-		// assumption that no notification larger than 2^64 will ever be sent.
-		let yamux_maximum_buffer_size = {
-			let requests_max = config
-				.request_response_protocols
-				.iter()
-				.map(|cfg| usize::try_from(cfg.max_request_size).unwrap_or(usize::MAX));
-			let responses_max = config
-				.request_response_protocols
-				.iter()
-				.map(|cfg| usize::try_from(cfg.max_response_size).unwrap_or(usize::MAX));
-			let notifs_max = config
-				.notification_protocols
-				.iter()
-				.map(|cfg| usize::try_from(cfg.max_notification_size()).unwrap_or(usize::MAX));
-
-			// A "default" max is added to cover all the other protocols: ping, identify,
-			// kademlia, block announces, and transactions.
-			let default_max = cmp::max(
-				1024 * 1024,
-				usize::try_from(protocol::BLOCK_ANNOUNCES_TRANSACTIONS_SUBSTREAM_SIZE)
-					.unwrap_or(usize::MAX),
-			);
-
-			iter::once(default_max)
-				.chain(requests_max)
-				.chain(responses_max)
-				.chain(notifs_max)
-				.max()
-				.expect("iterator known to always yield at least one element; qed")
-				.saturating_add(10)
-		};
-
-		let yamux_config = {
-			let mut yamux_config = litep2p::yamux::Config::default();
-			// Enable proper flow-control: window updates are only sent when
-			// buffered data has been consumed.
-			yamux_config.set_window_update_mode(litep2p::yamux::WindowUpdateMode::OnRead);
-			yamux_config.set_max_buffer_size(yamux_maximum_buffer_size);
-
-			if let Some(yamux_window_size) = config.network_config.yamux_window_size {
-				yamux_config.set_receive_window(yamux_window_size);
-			}
-
-			yamux_config
-		};
-
 		let (tcp, websocket): (Vec<Option<_>>, Vec<Option<_>>) = config
 			.network_config
 			.listen_addresses
@@ -365,13 +313,13 @@ impl Litep2pNetworkBackend {
 		config_builder
 			.with_websocket(WebSocketTransportConfig {
 				listen_addresses: websocket.into_iter().flatten().map(Into::into).collect(),
-				yamux_config: yamux_config.clone(),
+				yamux_config: litep2p::yamux::Config::default(),
 				nodelay: true,
 				..Default::default()
 			})
 			.with_tcp(TcpTransportConfig {
 				listen_addresses: tcp.into_iter().flatten().map(Into::into).collect(),
-				yamux_config,
+				yamux_config: litep2p::yamux::Config::default(),
 				nodelay: true,
 				..Default::default()
 			})

--- a/substrate/client/network/src/peer_info.rs
+++ b/substrate/client/network/src/peer_info.rs
@@ -19,7 +19,7 @@
 //! [`PeerInfoBehaviour`] is implementation of `NetworkBehaviour` that holds information about peers
 //! in cache.
 
-use crate::utils::interval;
+use crate::{utils::interval, LOG_TARGET};
 use either::Either;
 
 use fnv::FnvHashMap;
@@ -31,24 +31,26 @@ use libp2p::{
 		Info as IdentifyInfo,
 	},
 	identity::PublicKey,
+	multiaddr::Protocol,
 	ping::{Behaviour as Ping, Config as PingConfig, Event as PingEvent},
 	swarm::{
 		behaviour::{
-			AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure,
-			ExternalAddrConfirmed, FromSwarm, ListenFailure,
+			AddressChange, ConnectionClosed, ConnectionEstablished, DialFailure, FromSwarm,
+			ListenFailure,
 		},
 		ConnectionDenied, ConnectionHandler, ConnectionHandlerSelect, ConnectionId,
-		NetworkBehaviour, NewExternalAddrCandidate, THandler, THandlerInEvent, THandlerOutEvent,
-		ToSwarm,
+		NetworkBehaviour, THandler, THandlerInEvent, THandlerOutEvent, ToSwarm,
 	},
 	Multiaddr, PeerId,
 };
-use log::{debug, error, trace};
+use log::{debug, error, trace, warn};
 use parking_lot::Mutex;
+use schnellru::{ByLength, LruMap};
 use smallvec::SmallVec;
 
 use std::{
 	collections::{hash_map::Entry, HashSet, VecDeque},
+	iter,
 	pin::Pin,
 	sync::Arc,
 	task::{Context, Poll},
@@ -59,6 +61,11 @@ use std::{
 const CACHE_EXPIRE: Duration = Duration::from_secs(10 * 60);
 /// Interval at which we perform garbage collection on the node info.
 const GARBAGE_COLLECT_INTERVAL: Duration = Duration::from_secs(2 * 60);
+/// The maximum number of tracked external addresses we allow.
+const MAX_EXTERNAL_ADDRESSES: u32 = 32;
+/// Number of times observed address is received from different peers before it is confirmed as
+/// external.
+const MIN_ADDRESS_CONFIRMATIONS: usize = 3;
 
 /// Implementation of `NetworkBehaviour` that holds information about peers in cache.
 pub struct PeerInfoBehaviour {
@@ -70,7 +77,16 @@ pub struct PeerInfoBehaviour {
 	nodes_info: FnvHashMap<PeerId, NodeInfo>,
 	/// Interval at which we perform garbage collection in `nodes_info`.
 	garbage_collect: Pin<Box<dyn Stream<Item = ()> + Send>>,
+	/// PeerId of the local node.
+	local_peer_id: PeerId,
+	/// Public addresses supplied by the operator. Never expire.
+	public_addresses: Vec<Multiaddr>,
+	/// Listen addresses. External addresses matching listen addresses never expire.
+	listen_addresses: HashSet<Multiaddr>,
+	/// External address confirmations.
+	address_confirmations: LruMap<Multiaddr, HashSet<PeerId>>,
 	/// Record keeping of external addresses. Data is queried by the `NetworkService`.
+	/// The addresses contain the `/p2p/...` part with local peer ID.
 	external_addresses: ExternalAddresses,
 	/// Pending events to emit to [`Swarm`](libp2p::swarm::Swarm).
 	pending_actions: VecDeque<ToSwarm<PeerInfoEvent, THandlerInEvent<PeerInfoBehaviour>>>,
@@ -106,13 +122,13 @@ pub struct ExternalAddresses {
 
 impl ExternalAddresses {
 	/// Add an external address.
-	pub fn add(&mut self, addr: Multiaddr) {
-		self.addresses.lock().insert(addr);
+	pub fn add(&mut self, addr: Multiaddr) -> bool {
+		self.addresses.lock().insert(addr)
 	}
 
 	/// Remove an external address.
-	pub fn remove(&mut self, addr: &Multiaddr) {
-		self.addresses.lock().remove(addr);
+	pub fn remove(&mut self, addr: &Multiaddr) -> bool {
+		self.addresses.lock().remove(addr)
 	}
 }
 
@@ -122,9 +138,10 @@ impl PeerInfoBehaviour {
 		user_agent: String,
 		local_public_key: PublicKey,
 		external_addresses: Arc<Mutex<HashSet<Multiaddr>>>,
+		public_addresses: Vec<Multiaddr>,
 	) -> Self {
 		let identify = {
-			let cfg = IdentifyConfig::new("/substrate/1.0".to_string(), local_public_key)
+			let cfg = IdentifyConfig::new("/substrate/1.0".to_string(), local_public_key.clone())
 				.with_agent_version(user_agent)
 				// We don't need any peer information cached.
 				.with_cache_size(0);
@@ -136,6 +153,10 @@ impl PeerInfoBehaviour {
 			identify,
 			nodes_info: FnvHashMap::default(),
 			garbage_collect: Box::pin(interval(GARBAGE_COLLECT_INTERVAL)),
+			local_peer_id: local_public_key.to_peer_id(),
+			public_addresses,
+			listen_addresses: HashSet::new(),
+			address_confirmations: LruMap::new(ByLength::new(MAX_EXTERNAL_ADDRESSES)),
 			external_addresses: ExternalAddresses { addresses: external_addresses },
 			pending_actions: Default::default(),
 		}
@@ -158,25 +179,137 @@ impl PeerInfoBehaviour {
 		ping_time: Duration,
 		connection: ConnectionId,
 	) {
-		trace!(target: "sub-libp2p", "Ping time with {:?} via {:?}: {:?}", peer_id, connection, ping_time);
+		trace!(target: LOG_TARGET, "Ping time with {:?} via {:?}: {:?}", peer_id, connection, ping_time);
 		if let Some(entry) = self.nodes_info.get_mut(peer_id) {
 			entry.latest_ping = Some(ping_time);
 		} else {
-			error!(target: "sub-libp2p",
+			error!(target: LOG_TARGET,
 				"Received ping from node we're not connected to {:?} via {:?}", peer_id, connection);
 		}
 	}
 
-	/// Inserts an identify record in the cache. Has no effect if we don't have any entry for that
-	/// node, which shouldn't happen.
+	/// Ensure address has the `/p2p/...` part with local peer id. Returns `Err` if the address
+	/// already contains a different peer id.
+	fn with_local_peer_id(&self, address: Multiaddr) -> Result<Multiaddr, Multiaddr> {
+		if let Some(Protocol::P2p(peer_id)) = address.iter().last() {
+			if peer_id == self.local_peer_id {
+				Ok(address)
+			} else {
+				Err(address)
+			}
+		} else {
+			Ok(address.with(Protocol::P2p(self.local_peer_id)))
+		}
+	}
+
+	/// Inserts an identify record in the cache & discovers external addresses when multiple
+	/// peers report the same address as observed.
 	fn handle_identify_report(&mut self, peer_id: &PeerId, info: &IdentifyInfo) {
-		trace!(target: "sub-libp2p", "Identified {:?} => {:?}", peer_id, info);
+		trace!(target: LOG_TARGET, "Identified {:?} => {:?}", peer_id, info);
 		if let Some(entry) = self.nodes_info.get_mut(peer_id) {
 			entry.client_version = Some(info.agent_version.clone());
 		} else {
-			error!(target: "sub-libp2p",
-				"Received pong from node we're not connected to {:?}", peer_id);
+			error!(target: LOG_TARGET,
+				"Received identify message from node we're not connected to {peer_id:?}");
 		}
+		// Discover external addresses.
+		match self.with_local_peer_id(info.observed_addr.clone()) {
+			Ok(observed_addr) => {
+				let (is_new, expired) = self.is_new_external_address(&observed_addr, *peer_id);
+				if is_new && self.external_addresses.add(observed_addr.clone()) {
+					trace!(
+						target: LOG_TARGET,
+						"Observed address reported by Identify confirmed as external {}",
+						observed_addr,
+					);
+					self.pending_actions.push_back(ToSwarm::ExternalAddrConfirmed(observed_addr));
+				}
+				if let Some(expired) = expired {
+					trace!(target: LOG_TARGET, "Removing replaced external address: {expired}");
+					self.external_addresses.remove(&expired);
+					self.pending_actions.push_back(ToSwarm::ExternalAddrExpired(expired));
+				}
+			},
+			Err(addr) => {
+				warn!(
+					target: LOG_TARGET,
+					"Identify reported observed address for a peer that is not us: {addr}",
+				);
+			},
+		}
+	}
+
+	/// Check if addresses are equal taking into account they can contain or not contain
+	/// the `/p2p/...` part.
+	fn is_same_address(left: &Multiaddr, right: &Multiaddr) -> bool {
+		let mut left = left.iter();
+		let mut right = right.iter();
+
+		loop {
+			match (left.next(), right.next()) {
+				(None, None) => return true,
+				(None, Some(Protocol::P2p(_))) => return true,
+				(Some(Protocol::P2p(_)), None) => return true,
+				(left, right) if left != right => return false,
+				_ => {},
+			}
+		}
+	}
+
+	/// Check if `address` can be considered a new external address.
+	///
+	/// If this address replaces an older address, the expired address is returned.
+	fn is_new_external_address(
+		&mut self,
+		address: &Multiaddr,
+		peer_id: PeerId,
+	) -> (bool, Option<Multiaddr>) {
+		trace!(target: LOG_TARGET, "Verify new external address: {address}");
+
+		// Public and listen addresses don't count towards discovered external addresses
+		// and are always confirmed.
+		// Because they are not kept in the LRU, they are never replaced by discovered
+		// external addresses.
+		if self
+			.listen_addresses
+			.iter()
+			.chain(self.public_addresses.iter())
+			.any(|known_address| PeerInfoBehaviour::is_same_address(&known_address, &address))
+		{
+			return (true, None)
+		}
+
+		match self.address_confirmations.get(address) {
+			Some(confirmations) => {
+				confirmations.insert(peer_id);
+
+				if confirmations.len() >= MIN_ADDRESS_CONFIRMATIONS {
+					return (true, None)
+				}
+			},
+			None => {
+				let oldest = (self.address_confirmations.len() >=
+					self.address_confirmations.limiter().max_length() as usize)
+					.then(|| {
+						self.address_confirmations.pop_oldest().map(|(address, peers)| {
+							if peers.len() >= MIN_ADDRESS_CONFIRMATIONS {
+								return Some(address)
+							} else {
+								None
+							}
+						})
+					})
+					.flatten()
+					.flatten();
+
+				self.address_confirmations
+					.insert(address.clone(), iter::once(peer_id).collect());
+
+				return (false, oldest)
+			},
+		}
+
+		(false, None)
 	}
 }
 
@@ -346,7 +479,7 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 					}
 					entry.endpoints.retain(|ep| ep != endpoint)
 				} else {
-					error!(target: "sub-libp2p",
+					error!(target: LOG_TARGET,
 						"Unknown connection to {:?} closed: {:?}", peer_id, endpoint);
 				}
 			},
@@ -400,28 +533,36 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 				self.ping.on_swarm_event(FromSwarm::NewListener(e));
 				self.identify.on_swarm_event(FromSwarm::NewListener(e));
 			},
+			FromSwarm::NewListenAddr(e) => {
+				self.ping.on_swarm_event(FromSwarm::NewListenAddr(e));
+				self.identify.on_swarm_event(FromSwarm::NewListenAddr(e));
+				self.listen_addresses.insert(e.addr.clone());
+			},
 			FromSwarm::ExpiredListenAddr(e) => {
 				self.ping.on_swarm_event(FromSwarm::ExpiredListenAddr(e));
 				self.identify.on_swarm_event(FromSwarm::ExpiredListenAddr(e));
-				self.external_addresses.remove(e.addr);
+				self.listen_addresses.remove(e.addr);
+				// Remove matching external address.
+				match self.with_local_peer_id(e.addr.clone()) {
+					Ok(addr) => {
+						self.external_addresses.remove(&addr);
+						self.pending_actions.push_back(ToSwarm::ExternalAddrExpired(addr));
+					},
+					Err(addr) => {
+						warn!(
+							target: LOG_TARGET,
+							"Listen address expired with peer ID that is not us: {addr}",
+						);
+					},
+				}
 			},
-			FromSwarm::NewExternalAddrCandidate(e @ NewExternalAddrCandidate { addr }) => {
+			FromSwarm::NewExternalAddrCandidate(e) => {
 				self.ping.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
 				self.identify.on_swarm_event(FromSwarm::NewExternalAddrCandidate(e));
-
-				// Manually confirm all external address candidates.
-				// TODO: consider adding [AutoNAT protocol](https://docs.rs/libp2p/0.52.3/libp2p/autonat/index.html)
-				// (must go through the polkadot protocol spec) or implemeting heuristics for
-				// approving external address candidates. This can be done, for example, by
-				// approving only addresses reported by multiple peers.
-				// See also https://github.com/libp2p/rust-libp2p/pull/4721 introduced
-				// in libp2p v0.53 for heuristics approach.
-				self.pending_actions.push_back(ToSwarm::ExternalAddrConfirmed(addr.clone()));
 			},
-			FromSwarm::ExternalAddrConfirmed(e @ ExternalAddrConfirmed { addr }) => {
+			FromSwarm::ExternalAddrConfirmed(e) => {
 				self.ping.on_swarm_event(FromSwarm::ExternalAddrConfirmed(e));
 				self.identify.on_swarm_event(FromSwarm::ExternalAddrConfirmed(e));
-				self.external_addresses.add(addr.clone());
 			},
 			FromSwarm::AddressChange(e @ AddressChange { peer_id, old, new, .. }) => {
 				self.ping.on_swarm_event(FromSwarm::AddressChange(e));
@@ -431,20 +572,16 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 					if let Some(endpoint) = entry.endpoints.iter_mut().find(|e| e == &old) {
 						*endpoint = new.clone();
 					} else {
-						error!(target: "sub-libp2p",
+						error!(target: LOG_TARGET,
 							"Unknown address change for peer {:?} from {:?} to {:?}", peer_id, old, new);
 					}
 				} else {
-					error!(target: "sub-libp2p",
+					error!(target: LOG_TARGET,
 						"Unknown peer {:?} to change address from {:?} to {:?}", peer_id, old, new);
 				}
 			},
-			FromSwarm::NewListenAddr(e) => {
-				self.ping.on_swarm_event(FromSwarm::NewListenAddr(e));
-				self.identify.on_swarm_event(FromSwarm::NewListenAddr(e));
-			},
 			event => {
-				debug!(target: "sub-libp2p", "New unknown `FromSwarm` libp2p event: {event:?}");
+				debug!(target: LOG_TARGET, "New unknown `FromSwarm` libp2p event: {event:?}");
 				self.ping.on_swarm_event(event);
 				self.identify.on_swarm_event(event);
 			},
@@ -497,7 +634,7 @@ impl NetworkBehaviour for PeerInfoBehaviour {
 					},
 					IdentifyEvent::Error { connection_id, peer_id, error } => {
 						debug!(
-							target: "sub-libp2p",
+							target: LOG_TARGET,
 							"Identification with peer {peer_id:?}({connection_id}) failed => {error}"
 						);
 					},

--- a/substrate/client/network/src/protocol.rs
+++ b/substrate/client/network/src/protocol.rs
@@ -22,7 +22,6 @@ use crate::{
 	protocol_controller::{self, SetId},
 	service::{metrics::NotificationMetrics, traits::Direction},
 	types::ProtocolName,
-	MAX_RESPONSE_SIZE,
 };
 
 use codec::Encode;
@@ -53,9 +52,8 @@ mod notifications;
 
 pub mod message;
 
-/// Maximum size used for notifications in the block announce and transaction protocols.
-// Must be equal to `max(MAX_BLOCK_ANNOUNCE_SIZE, MAX_TRANSACTIONS_SIZE)`.
-pub(crate) const BLOCK_ANNOUNCES_TRANSACTIONS_SUBSTREAM_SIZE: u64 = MAX_RESPONSE_SIZE;
+// Log target for this file.
+const LOG_TARGET: &str = "sub-libp2p";
 
 /// Identifier of the peerset for the block announces protocol.
 const HARDCODED_PEERSETS_SYNC: SetId = SetId::from(0);

--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -703,7 +703,7 @@ impl Notifications {
 					self.events.push_back(ToSwarm::NotifyHandler {
 						peer_id,
 						handler: NotifyHandler::One(*connec_id),
-						event: NotifsHandlerIn::Open { protocol_index: set_id.into() },
+						event: NotifsHandlerIn::Open { protocol_index: set_id.into(), peer_id },
 					});
 					*connec_state = ConnectionState::Opening;
 					*occ_entry.into_mut() = PeerState::Enabled { connections };
@@ -1062,7 +1062,10 @@ impl Notifications {
 					self.events.push_back(ToSwarm::NotifyHandler {
 						peer_id: incoming.peer_id,
 						handler: NotifyHandler::One(*connec_id),
-						event: NotifsHandlerIn::Open { protocol_index: incoming.set_id.into() },
+						event: NotifsHandlerIn::Open {
+							protocol_index: incoming.set_id.into(),
+							peer_id: incoming.peer_id,
+						},
 					});
 					*connec_state = ConnectionState::Opening;
 				}
@@ -1260,7 +1263,10 @@ impl NetworkBehaviour for Notifications {
 							self.events.push_back(ToSwarm::NotifyHandler {
 								peer_id,
 								handler: NotifyHandler::One(connection_id),
-								event: NotifsHandlerIn::Open { protocol_index: set_id.into() },
+								event: NotifsHandlerIn::Open {
+									protocol_index: set_id.into(),
+									peer_id,
+								},
 							});
 
 							let mut connections = SmallVec::new();
@@ -1762,7 +1768,10 @@ impl NetworkBehaviour for Notifications {
 								self.events.push_back(ToSwarm::NotifyHandler {
 									peer_id,
 									handler: NotifyHandler::One(connection_id),
-									event: NotifsHandlerIn::Open { protocol_index: set_id.into() },
+									event: NotifsHandlerIn::Open {
+										protocol_index: set_id.into(),
+										peer_id,
+									},
 								});
 								*connec_state = ConnectionState::Opening;
 							} else {
@@ -1849,7 +1858,10 @@ impl NetworkBehaviour for Notifications {
 								self.events.push_back(ToSwarm::NotifyHandler {
 									peer_id,
 									handler: NotifyHandler::One(connection_id),
-									event: NotifsHandlerIn::Open { protocol_index: set_id.into() },
+									event: NotifsHandlerIn::Open {
+										protocol_index: set_id.into(),
+										peer_id,
+									},
 								});
 								*connec_state = ConnectionState::Opening;
 
@@ -2336,7 +2348,7 @@ impl NetworkBehaviour for Notifications {
 						self.events.push_back(ToSwarm::NotifyHandler {
 							peer_id,
 							handler: NotifyHandler::One(*connec_id),
-							event: NotifsHandlerIn::Open { protocol_index: set_id.into() },
+							event: NotifsHandlerIn::Open { protocol_index: set_id.into(), peer_id },
 						});
 						*connec_state = ConnectionState::Opening;
 						*peer_state = PeerState::Enabled { connections: mem::take(connections) };

--- a/substrate/client/network/src/protocol/notifications/behaviour.rs
+++ b/substrate/client/network/src/protocol/notifications/behaviour.rs
@@ -1678,6 +1678,7 @@ impl NetworkBehaviour for Notifications {
 			FromSwarm::ExternalAddrConfirmed(_) => {},
 			FromSwarm::AddressChange(_) => {},
 			FromSwarm::NewListenAddr(_) => {},
+			FromSwarm::NewExternalAddrOfPeer(_) => {},
 			event => {
 				warn!(target: "sub-libp2p", "New unknown `FromSwarm` libp2p event: {event:?}");
 			},

--- a/substrate/client/network/src/protocol/notifications/handler.rs
+++ b/substrate/client/network/src/protocol/notifications/handler.rs
@@ -261,6 +261,9 @@ pub enum NotifsHandlerIn {
 	Open {
 		/// Index of the protocol in the list of protocols passed at initialization.
 		protocol_index: usize,
+
+		/// The peer id of the remote.
+		peer_id: PeerId,
 	},
 
 	/// Instruct the handler to close the notification substreams, or reject any pending incoming
@@ -629,7 +632,7 @@ impl ConnectionHandler for NotifsHandler {
 
 	fn on_behaviour_event(&mut self, message: NotifsHandlerIn) {
 		match message {
-			NotifsHandlerIn::Open { protocol_index } => {
+			NotifsHandlerIn::Open { protocol_index, peer_id } => {
 				let protocol_info = &mut self.protocols[protocol_index];
 				match &mut protocol_info.state {
 					State::Closed { pending_opening } => {
@@ -639,6 +642,7 @@ impl ConnectionHandler for NotifsHandler {
 								protocol_info.config.fallback_names.clone(),
 								protocol_info.config.handshake.read().clone(),
 								protocol_info.config.max_notification_size,
+								peer_id,
 							);
 
 							self.events_queue.push_back(
@@ -660,6 +664,7 @@ impl ConnectionHandler for NotifsHandler {
 								protocol_info.config.fallback_names.clone(),
 								handshake_message.clone(),
 								protocol_info.config.max_notification_size,
+								peer_id,
 							);
 
 							self.events_queue.push_back(
@@ -1199,7 +1204,10 @@ pub mod tests {
 		.await;
 
 		// move the handler state to 'Opening'
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }
@@ -1270,7 +1278,10 @@ pub mod tests {
 		.await;
 
 		// move the handler state to 'Opening'
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }
@@ -1359,7 +1370,10 @@ pub mod tests {
 
 		// first instruct the handler to open a connection and then close it right after
 		// so the handler is in state `Closed { pending_opening: true }`
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }
@@ -1418,7 +1432,10 @@ pub mod tests {
 
 		// first instruct the handler to open a connection and then close it right after
 		// so the handler is in state `Closed { pending_opening: true }`
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }
@@ -1499,7 +1516,10 @@ pub mod tests {
 
 		// first instruct the handler to open a connection and then close it right after
 		// so the handler is in state `Closed { pending_opening: true }`
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }
@@ -1547,7 +1567,10 @@ pub mod tests {
 
 		// first instruct the handler to open a connection and then close it right after
 		// so the handler is in state `Closed { pending_opening: true }`
-		handler.on_behaviour_event(NotifsHandlerIn::Open { protocol_index: 0 });
+		handler.on_behaviour_event(NotifsHandlerIn::Open {
+			protocol_index: 0,
+			peer_id: PeerId::random(),
+		});
 		assert!(std::matches!(
 			handler.protocols[0].state,
 			State::Opening { in_substream: Some(_), .. }

--- a/substrate/client/network/src/protocol/notifications/upgrade/notifications.rs
+++ b/substrate/client/network/src/protocol/notifications/upgrade/notifications.rs
@@ -39,8 +39,11 @@ use crate::types::ProtocolName;
 use asynchronous_codec::Framed;
 use bytes::BytesMut;
 use futures::prelude::*;
-use libp2p::core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo};
-use log::{error, warn};
+use libp2p::{
+	core::{InboundUpgrade, OutboundUpgrade, UpgradeInfo},
+	PeerId,
+};
+use log::{debug, error, warn};
 use unsigned_varint::codec::UviBytes;
 
 use std::{
@@ -75,6 +78,8 @@ pub struct NotificationsOut {
 	initial_message: Vec<u8>,
 	/// Maximum allowed size for a single notification.
 	max_notification_size: u64,
+	/// The peerID of the remote.
+	peer_id: PeerId,
 }
 
 /// A substream for incoming notification messages.
@@ -111,12 +116,15 @@ pub struct NotificationsOutSubstream<TSubstream> {
 	/// Substream where to send messages.
 	#[pin]
 	socket: Framed<TSubstream, UviBytes<io::Cursor<Vec<u8>>>>,
+
+	/// The remote peer.
+	peer_id: PeerId,
 }
 
 #[cfg(test)]
 impl<TSubstream> NotificationsOutSubstream<TSubstream> {
 	pub fn new(socket: Framed<TSubstream, UviBytes<io::Cursor<Vec<u8>>>>) -> Self {
-		Self { socket }
+		Self { socket, peer_id: PeerId::random() }
 	}
 }
 
@@ -346,6 +354,7 @@ impl NotificationsOut {
 		fallback_names: Vec<ProtocolName>,
 		initial_message: impl Into<Vec<u8>>,
 		max_notification_size: u64,
+		peer_id: PeerId,
 	) -> Self {
 		let initial_message = initial_message.into();
 		if initial_message.len() > MAX_HANDSHAKE_SIZE {
@@ -355,7 +364,7 @@ impl NotificationsOut {
 		let mut protocol_names = fallback_names;
 		protocol_names.insert(0, main_protocol_name.into());
 
-		Self { protocol_names, initial_message, max_notification_size }
+		Self { protocol_names, initial_message, max_notification_size, peer_id }
 	}
 }
 
@@ -411,7 +420,10 @@ where
 				} else {
 					Some(negotiated_name)
 				},
-				substream: NotificationsOutSubstream { socket: Framed::new(socket, codec) },
+				substream: NotificationsOutSubstream {
+					socket: Framed::new(socket, codec),
+					peer_id: self.peer_id,
+				},
 			})
 		})
 	}
@@ -462,11 +474,25 @@ where
 		// even if we don't write anything into it.
 		match Stream::poll_next(this.socket.as_mut(), cx) {
 			Poll::Pending => {},
-			Poll::Ready(Some(_)) => {
-				error!(
-					target: "sub-libp2p",
-					"Unexpected incoming data in `NotificationsOutSubstream`",
-				);
+			Poll::Ready(Some(result)) => match result {
+				Ok(_) => {
+					error!(
+						target: "sub-libp2p",
+						"Unexpected incoming data in `NotificationsOutSubstream` peer={:?}",
+						this.peer_id
+					);
+				},
+				Err(error) => {
+					debug!(
+						target: "sub-libp2p",
+						"Error while reading from `NotificationsOutSubstream` peer={:?} error={error:?}",
+						this.peer_id
+					);
+
+					// The expectation is that the remote has closed the substream.
+					// This is similar to the `Poll::Ready(None)` branch below.
+					return Poll::Ready(Err(NotificationsOutError::Terminated));
+				},
 			},
 			Poll::Ready(None) => return Poll::Ready(Err(NotificationsOutError::Terminated)),
 		}
@@ -534,7 +560,10 @@ mod tests {
 		NotificationsOutSubstream,
 	};
 	use futures::{channel::oneshot, future, prelude::*, SinkExt, StreamExt};
-	use libp2p::core::{upgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo};
+	use libp2p::{
+		core::{upgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo},
+		PeerId,
+	};
 	use std::{pin::Pin, task::Poll};
 	use tokio::net::{TcpListener, TcpStream};
 	use tokio_util::compat::TokioAsyncReadCompatExt;
@@ -554,7 +583,13 @@ mod tests {
 		NotificationsHandshakeError,
 	> {
 		let socket = TcpStream::connect(addr).await.unwrap();
-		let notifs_out = NotificationsOut::new("/test/proto/1", Vec::new(), handshake, 1024 * 1024);
+		let notifs_out = NotificationsOut::new(
+			"/test/proto/1",
+			Vec::new(),
+			handshake,
+			1024 * 1024,
+			PeerId::random(),
+		);
 		let (_, substream) = multistream_select::dialer_select_proto(
 			socket.compat(),
 			notifs_out.protocol_info(),
@@ -718,7 +753,13 @@ mod tests {
 		let client = tokio::spawn(async move {
 			let socket = TcpStream::connect(listener_addr_rx.await.unwrap()).await.unwrap();
 			let NotificationsOutOpen { handshake, .. } = OutboundUpgrade::upgrade_outbound(
-				NotificationsOut::new(PROTO_NAME, Vec::new(), &b"initial message"[..], 1024 * 1024),
+				NotificationsOut::new(
+					PROTO_NAME,
+					Vec::new(),
+					&b"initial message"[..],
+					1024 * 1024,
+					PeerId::random(),
+				),
 				socket.compat(),
 				ProtocolName::Static(PROTO_NAME),
 			)
@@ -763,6 +804,7 @@ mod tests {
 						Vec::new(),
 						&b"initial message"[..],
 						1024 * 1024,
+						PeerId::random(),
 					),
 					socket.compat(),
 					ProtocolName::Static(PROTO_NAME),

--- a/substrate/client/network/src/service.rs
+++ b/substrate/client/network/src/service.rs
@@ -516,6 +516,7 @@ where
 					request_response_protocols,
 					Arc::clone(&peer_store_handle),
 					external_addresses.clone(),
+					network_config.public_addresses.iter().cloned().map(Into::into).collect(),
 					ConnectionLimits::default()
 						.with_max_established_per_peer(Some(crate::MAX_CONNECTIONS_PER_PEER as u32))
 						.with_max_established_incoming(Some(


### PR DESCRIPTION
This PR cherry-picks these 3 network connection/stream bug fixes to our substrate fork:

Peer address autodetection fix, which works around a libp2p bug that pollutes the peer set with ephemeral outbound ports:
- https://github.com/paritytech/polkadot-sdk/pull/7338

Peer connection substream fixes, which correctly detect and react to I/O errors on connections by closing substreams: 
- https://github.com/paritytech/polkadot-sdk/pull/7640
- https://github.com/paritytech/polkadot-sdk/pull/7724

Part of the fix for:
https://github.com/autonomys/subspace/issues/3450