### PR TITLE
Remove `#[no_mangle]` from the panic handler (#8198)

### DIFF
--- a/substrate/primitives/io/src/lib.rs
+++ b/substrate/primitives/io/src/lib.rs
@@ -1750,7 +1750,6 @@ pub fn unreachable() -> ! {
 /// A default panic handler for the runtime environment.
 #[cfg(all(not(feature = "disable_panic_handler"), substrate_runtime))]
 #[panic_handler]
-#[no_mangle]
 pub fn panic(info: &core::panic::PanicInfo) -> ! {
 	let message = alloc::format!("{}", info);
 	#[cfg(feature = "improved_panic_error_reporting")]


### PR DESCRIPTION
This PR fixes building and executing runtimes with Rust 1.87.

This is a backport of the code changes in https://github.com/paritytech/polkadot-sdk/pull/8198

----

Fixes https://github.com/paritytech/polkadot-sdk/issues/8190

Remove useless `#[no_mangle]` from the panic handler which screws up the panic handling machinery on recent versions of Rust.
